### PR TITLE
Test the scrapers against saved copies of the pages they parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -28,3 +31,29 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test
+      run: python -m unittest discover -s tests -t . -v
+
+  # The fixtures are a frozen copy, so they can only catch us breaking the parser.
+  # This job is what notices Jagex changing their markup. Separate from `build` on
+  # purpose: when it goes red next to a green build, the cause is the site, not the
+  # commit. The weekly cron covers the stretches with no pushes — note GitHub
+  # disables cron workflows after 60 days of repo inactivity.
+  live-scrape:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.13"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Scrape the live pages
+      env:
+        RUN_LIVE_SCRAPE_TESTS: "1"
+      run: python -m unittest tests.test_parsers.LiveScrapeTest -v

--- a/rs_tracker.py
+++ b/rs_tracker.py
@@ -20,6 +20,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+def parse_osrs_count(html):
+    """Pull the total player count out of the front page. None if absent."""
+    match = re.search(r"([\d,]+)\s*(?:people playing|players online)", html, re.IGNORECASE)
+    if match:
+        return int(match.group(1).replace(',', ''))
+    return None
+
 def get_osrs_count():
     try:
         headers = {'User-Agent': USER_AGENT}
@@ -27,15 +34,70 @@ def get_osrs_count():
         response = requests.get(OSRS_MAIN_URL, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
-        # Find the number in the HTML
-        match = re.search(r"([\d,]+)\s*(?:people playing|players online)", response.text, re.IGNORECASE)
-        if match:
-            return int(match.group(1).replace(',', ''))
+        return parse_osrs_count(response.text)
 
     except Exception as e:
         logger.error(f"Error scraping total count: {e}")
 
     return None
+
+def parse_world_data(html):
+    """Pull one dict per world out of the /slu server list.
+
+    Split out from the fetch so it can be tested against a saved page —
+    Jagex changing this markup is the likeliest way the tracker breaks.
+    """
+    soup = BeautifulSoup(html, 'html.parser')
+    world_rows = []
+
+    # Find all rows with class 'server-list__row'
+    rows = soup.find_all('tr', class_='server-list__row')
+
+    for row in rows:
+        cells = row.find_all('td')
+        if len(cells) < 5:
+            continue
+
+        # 1. World Number
+        world_link = cells[0].find('a', class_='server-list__world-link')
+        if not world_link:
+            continue
+        world_text = world_link.get_text(strip=True) # e.g., "Old School 93"
+        # Extract number
+        world_match = re.search(r"Old School (\d+)", world_text)
+        if not world_match:
+            continue
+        world_number = int(world_match.group(1))
+
+        # 2. Player Count
+        players_text = cells[1].get_text(strip=True) # e.g., "48 players"
+        player_match = re.search(r"([\d,]+)", players_text)
+
+        if player_match:
+            player_count = int(player_match.group(1).replace(',', ''))
+        else:
+            # If no number is found, it means the world is full (2000 players)
+            player_count = 2000
+
+        # 3. Location
+        location = cells[2].get_text(strip=True)
+
+        # 4. Type
+        type_text = cells[3].get_text(strip=True).lower()
+        is_f2p = 'free' in type_text
+
+        # 5. Activity
+        activity = cells[4].get_text(strip=True)
+
+        world_rows.append({
+            'world_number': world_number,
+            'player_count': player_count,
+            'location': location,
+            'is_f2p': is_f2p,
+            'activity': activity
+        })
+
+    return world_rows
 
 def get_world_data():
     try:
@@ -43,57 +105,7 @@ def get_world_data():
         response = requests.get(OSRS_SLU_URL, headers=headers, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
-        soup = BeautifulSoup(response.content, 'html.parser')
-        world_rows = []
-        
-        # Find all rows with class 'server-list__row'
-        rows = soup.find_all('tr', class_='server-list__row')
-        
-        for row in rows:
-            cells = row.find_all('td')
-            if len(cells) < 5:
-                continue
-                
-            # 1. World Number
-            world_link = cells[0].find('a', class_='server-list__world-link')
-            if not world_link:
-                continue
-            world_text = world_link.get_text(strip=True) # e.g., "Old School 93"
-            # Extract number
-            world_match = re.search(r"Old School (\d+)", world_text)
-            if not world_match:
-                continue
-            world_number = int(world_match.group(1))
-            
-            # 2. Player Count
-            players_text = cells[1].get_text(strip=True) # e.g., "48 players"
-            player_match = re.search(r"([\d,]+)", players_text)
-            
-            if player_match:
-                player_count = int(player_match.group(1).replace(',', ''))
-            else:
-                # If no number is found, it means the world is full (2000 players)
-                player_count = 2000
-            
-            # 3. Location
-            location = cells[2].get_text(strip=True)
-            
-            # 4. Type
-            type_text = cells[3].get_text(strip=True).lower()
-            is_f2p = 'free' in type_text
-            
-            # 5. Activity
-            activity = cells[4].get_text(strip=True)
-            
-            world_rows.append({
-                'world_number': world_number,
-                'player_count': player_count,
-                'location': location,
-                'is_f2p': is_f2p,
-                'activity': activity
-            })
-            
-        return world_rows
+        return parse_world_data(response.content)
 
     except Exception as e:
         logger.error(f"Error scraping world data: {e}")

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,34 @@
+# Scrape fixtures
+
+Verbatim captures of the two pages `rs_tracker.py` scrapes, used by `tests/test_parsers.py`.
+Captured 2026-08-04.
+
+| file | source |
+|---|---|
+| `slu.html` | <https://oldschool.runescape.com/slu> |
+| `index.html` | <https://oldschool.runescape.com/> |
+
+## What these do and don't catch
+
+They catch **us** breaking the parsers — a refactor that drops a column, mishandles the
+full-world case, or changes a returned key.
+
+They do **not** catch **Jagex** changing their markup, because they're a frozen copy. That's what
+the live check is for: `RUN_LIVE_SCRAPE_TESTS=1 python -m unittest tests.test_parsers` hits the real
+pages and asserts the parsers still find plausible data.
+
+CI runs it as its own `live-scrape` job on every push and PR, plus a weekly cron for quiet stretches.
+The env-var gate exists so the *local* run stays offline, fast and deterministic — not to keep it
+out of CI.
+
+## Refreshing
+
+```sh
+curl -A "$(python -c 'import config; print(config.USER_AGENT)')" \
+    -o tests/fixtures/slu.html   https://oldschool.runescape.com/slu
+curl -A "$(python -c 'import config; print(config.USER_AGENT)')" \
+    -o tests/fixtures/index.html https://oldschool.runescape.com/
+```
+
+Then re-run the tests and update the expected counts at the top of `test_parsers.py`. A refresh
+that makes the tests fail *is the signal* — read the diff before fixing the assertions.

--- a/tests/fixtures/index.html
+++ b/tests/fixtures/index.html
@@ -1,0 +1,407 @@
+<!doctype html>
+    <!--[if lt IE 7]><html class='no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7' lang='en'><![endif]-->
+    <!--[if (IE 7)&!(IEMobile)]><html class='no-js lt-ie10 lt-ie9 lt-ie8' lang='en'><![endif]-->
+    <!--[if (IE 8)&!(IEMobile)]><html class='no-js lt-ie10 lt-ie9' lang='en'><![endif]-->
+    <!--[if (IE 9)&!(IEMobile)]><html class='no-js lt-ie10' lang='en'><![endif]-->
+    <!--[if gt IE 9]><!--><!-- x --> <html class='no-js no-autoplay' lang='en'> <!--<![endif]-->
+<head>
+    <title>Old School RuneScape - Play Old School RS</title>
+		<meta name='description' content="If you&#39;re a RuneScape veteran hungry for nostalgia, get stuck right in to Old School RuneScape. Sign up for membership and re-live the adventure."/>
+    <meta name='author' content='Jagex'/>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <link rel='dns-prefetch' href='//www.google-analytics.com' />
+    <link rel='dns-prefetch' href='//ajax.googleapis.com' />
+    <link rel='dns-prefetch' href='//connect.facebook.net' />
+    <link href='https://www.runescape.com/css/c/oldschool-128.css' rel='stylesheet' />
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-16x16.png?1' sizes='16x16' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-32x32.png?1' sizes='32x32' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-96x96.png?1' sizes='96x96' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-128x128.png?1' sizes='128x128' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-144x144.png?1' sizes='144x144' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-196x196.png?1' sizes='196x196' type='image/png'>
+    <link rel='shortcut icon' href='https://www.runescape.com/img/rsp777/favicon.ico?1' sizes="64x64">
+    <link rel='apple-touch-icon' href='https://www.runescape.com/img/rsp777/os-favicon.png?1'>
+	<link rel='apple-touch-icon-precomposed' sizes='57x57' href='https://www.runescape.com/img/rsp777/apple-touch-icon-57x57.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='114x114' href='https://www.runescape.com/img/rsp777/apple-touch-icon-114x114.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='72x72' href='https://www.runescape.com/img/rsp777/apple-touch-icon-72x72.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='144x144' href='https://www.runescape.com/img/rsp777/apple-touch-icon-144x144.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='60x60' href='https://www.runescape.com/img/rsp777/apple-touch-icon-60x60.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='120x120' href='https://www.runescape.com/img/rsp777/apple-touch-icon-120x120.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='76x76' href='https://www.runescape.com/img/rsp777/apple-touch-icon-76x76.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='152x152' href='https://www.runescape.com/img/rsp777/apple-touch-icon-152x152.png?1' />
+	<meta name='application-name' content="Old School RuneScape Website"/>
+	<meta name='msapplication-TileColor' content='#1317FB' />
+	<meta name='msapplication-TileImage' content='https://www.runescape.com/img/rsp777/mstile-144x144.png?1' />
+	<meta name='msapplication-square70x70logo' content='https://www.runescape.com/img/rsp777/mstile-70x70.png?1' />
+	<meta name='msapplication-square150x150logo' content='https://www.runescape.com/img/rsp777/mstile-150x150.png?1' />
+	<meta name='msapplication-wide310x150logo' content='https://www.runescape.com/img/rsp777/mstile-310x150.png?1' />
+	<meta name='msapplication-square310x310logo' content='https://www.runescape.com/img/rsp777/mstile-310x310.png?1' />
+
+		<meta property='og:title' content="Old School RuneScape - Play Old School RS" />
+		<meta property='og:site_name' content='Old School RuneScape' />
+    <meta property='og:image' content='https://www.runescape.com/img/rsp777/social-share-fb.jpg?1' />
+    <meta property='og:image' content='https://www.runescape.com/img/rsp777/os-og-image.jpg?1' />
+    <meta property='og:url' content='https://oldschool.runescape.com/' />
+		<meta property='og:description' content="If you&#39;re a RuneScape veteran hungry for nostalgia, get stuck right in to Old School RuneScape. Sign up for membership and re-live the adventure." />
+	<meta name='twitter:card' content='summary_large_image'/>
+    <meta name='twitter:domain' content='Oldschool.RuneScape.com'>
+    <meta name='twitter:url' content='https://oldschool.runescape.com/'>
+		<meta name='twitter:title' content="Old School RuneScape - Play Old School RS">
+		<meta name='twitter:description' content="If you&#39;re a RuneScape veteran hungry for nostalgia, get stuck right in to Old School RuneScape. Sign up for membership and re-live the adventure.">
+    <meta name='twitter:image:src' content='https://www.runescape.com/img/rsp777/social-share.jpg?1'>
+    <meta name='twitter:site' content='@OldSchoolRS'>
+    <meta name='google-site-verification' content='pUwl5KYHKSZ6tbbgsR2wYNv1kbVmsYral3iFmijHTWM' />
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag("consent", "default", {
+            ad_storage: "denied",
+            analytics_storage: "denied",
+            functionality_storage: "denied",
+            personalization_storage: "denied",
+            ad_personalization: "denied",
+            ad_user_data: "denied",
+            security_storage: "granted",
+            wait_for_update: 1500,
+        });
+        gtag("set", "ads_data_redaction", true);
+        (function(){
+            function hasGroup(id) {
+                return typeof window.OnetrustActiveGroups === "string" &&
+                    window.OnetrustActiveGroups.indexOf(id) > -1;
+            }
+            function syncGCM(){
+                if (typeof window.gtag !== "function") return;
+                if (typeof window.OnetrustActiveGroups !== "string") return;
+                gtag("consent", "update", {
+                    ad_personalization:         hasGroup("C0004") ? "granted" : "denied",
+                    ad_storage:                 hasGroup("C0004") ? "granted" : "denied",
+                    ad_user_data:               hasGroup("C0004") ? "granted" : "denied",
+                    analytics_storage:          hasGroup("C0002") ? "granted" : "denied",
+                    functionality_storage:      hasGroup("C0003") ? "granted" : "denied",
+                    personalization_storage:    hasGroup("C0003") ? "granted" : "denied",
+                    security_storage:           "granted",
+                });
+                dataLayer.push({event: "cookie_consent_update", onetrust_groups: window.OnetrustActiveGroups});
+            }
+            window.addEventListener("OneTrustGroupsUpdated", syncGCM, false);
+            syncGCM();
+        })();
+    </script>
+    <script src='https://cdn-ukwest.onetrust.com/consent/019b25be-0577-738e-8af0-4b232af181c1/OtAutoBlock.js'></script>
+    <script data-ot-ignore>
+        !(function (w, d, s, u) {
+            w._athena = w._athena || {};
+            w._athena.queue = w._athena.queue || [];
+
+            function athena(component, method, callback, ...args) {
+                const call = { component, method, callback, args };
+
+                if (typeof w._athena.direct === "function") {
+                    w._athena.direct(call);
+                    return;
+                }
+
+                w._athena.queue.push(call);
+            }
+
+            w.athena = w.athena || athena;
+
+            var f = d.getElementsByTagName(s)[0];
+            var js = d.createElement(s);
+            js.src = u;
+            js.async = true;
+            js.setAttribute("data-consent-domain", "runescape.com");
+            js.setAttribute("data-environment", "production");
+            js.setAttribute("data-acquisition-product-id", "com.runescape.oldschool");
+            js.setAttribute("data-acquisition-domain", "runescape.com");
+            js.setAttribute("data-ot-ignore", "true");
+            f.parentNode.insertBefore(js, f);
+        })(window, document, "script", 'https://athena.runescape.com/athena.0.latest.js');
+    </script>
+	<link rel='canonical' href='https://oldschool.runescape.com/' />
+    <meta name='apple-itunes-app' content='app-id=1269648762' />
+    <script type="speculationrules">
+        {
+            "prerender": [
+                {
+                    "where": {
+                        "and": [
+                            { "href_matches": "/*" },
+                            { "not": { "href_matches": "/logout" }}
+                        ]
+                    },
+                    "eagerness": "moderate"
+                },
+                {
+                    "where": {
+                        "and": [
+                            { "selector_matches": ".a-button" },
+                            { "not": { "selector_matches": ".a-button--style-hollow" }},
+                            { "not": { "href_matches": "/logout" }}
+                        ]
+                    }
+                }
+            ]
+        }
+    </script>
+    <style>
+        @view-transition {
+            navigation: auto;
+        }
+    </style>
+		<script>var bStyle = document.createElement('style'); bStyle.type = 'text/css'; bStyle.setAttribute('id', 'bConHide'); bStyle.appendChild(document.createTextNode('body { opacity: 0!important; filter: alpha(opacity=0)!important; background: none!important; }')); document.head.appendChild(bStyle);</script>
+    </head>
+	<body id='os-home' class='os-home home'>
+		<div class='page-wrap'>
+    	<span class='login-box'><a href='https://secure.runescape.com/m=weblogin/loginform?theme=oldschool&amp;mod=oldschool&amp;ssl=1&amp;dest=' id='showOsLogin' class='login-box__login-link'>Log in</a></span>
+    <header class='banner'>
+        <div class='banner__options'>
+			<h1 class='banner__title'>Old School RuneScape</h1>
+			<a id='banner-home' class='banner__home' href='https://oldschool.runescape.com/'>Home</a>
+        </div>
+    </header>
+    <div class='contents'>
+        <main class='main'>
+            <p class='player-count'>There are currently 131,884 people playing!</p>
+			<div class='home-nav'>
+				<nav class='home-nav__main-nav'>
+                    <div class='home-nav__box'>
+                        <h3 class='home-nav__title'>Game</h3>
+                        <ul class='home-nav__list'>
+                            <li>
+                                <a class='home-nav__link home-nav__link--client' id='osnav-client' data-test='osnav-client' href='https://oldschool.runescape.com/play'>Download Old School</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--worlds' id='osnav-worldselect' data-test='osnav-worldselect' href='https://oldschool.runescape.com/slu'>World Select</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--map' id='osnav-map' data-test='osnav-map' href='https://oldschool.runescape.com/world-map'>World Map</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--redeem-code' id='osnav-redeem-code' data-test='osnav-redeem-code' href='https://secure.runescape.com/m=billing_core/voucherform.ws'>Redeem Code</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--news' id='osnav-archive' data-test='osnav-archive' href='https://secure.runescape.com/m=news/archive?oldschool=1'>News</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--mobile' id='osnav-mobile' data-test='osnav-mobile' href='https://oldschool.runescape.com/mobile'>Mobile</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--status' id='osnav-status' data-test='osnav-status' href='https://oldschool.runescape.com/game-status'>Status</a>
+                            </li>
+                         
+                            <li>
+                                <a class='home-nav__link home-nav__link--newplayerguide' id='osnav-newplayerguide' data-test='osnav-newplayerguide' href='https://secure.runescape.com/m=news/new-player-guide-settings--set-up?oldschool=1'>New Player Guide</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class='home-nav__box'>
+                        <h3 class='home-nav__title'>Community <a class='home-nav__disclaimer' href='#osrs-disclaimer' aria-describedby='osrs-disclaimer'>*</a></h3>
+                        <ul class='home-nav__list'>
+                            <li>
+                                <a class='home-nav__link home-nav__link--polls' id='osnav-polls' data-test='osnav-polls' href='https://oldschool.runescape.com/polls'>Polls</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--polls' id='osnav-poll-charter' data-test='osnav-poll-charter' href='https://oldschool.runescape.com/poll-charter'>Polling Charter</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--hiscores' id='osnav-hiscores' data-test='osnav-hiscores' href='https://secure.runescape.com/m=hiscore_oldschool/overall'>HiScores</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--roadmap' id='osnav-roadmap' data-test='osnav-roadmap' href='https://secure.runescape.com/m=news/old-school-roadmap?oldschool=1'>Roadmap</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--exchange' id='osnav-exchange' data-test='osnav-exchange' href="https://secure.runescape.com/m=itemdb_oldschool/">Grand Exchange</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--external home-nav__link--discord' id='osnav-discord' data-test='osnav-discord' href='https://discord.gg/osrs'>Discord</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--external home-nav__link--shop' id='osnav-shop' data-test='osnav-shop' href='https://runescapemerch.com' target='_blank' rel='noopener'>Merchandise</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--external home-nav__link--wiki' id='osnav-wiki' data-test='osnav-wiki' href='https://oldschool.runescape.wiki' target='_blank' rel='noopener'>Wiki</a>
+                            </li>
+                                <li>
+                                    <a class='home-nav__link home-nav__link--external home-nav__link--runelite' id='osnav-runelite' data-test='osnav-runelite' href='https://runelite.net/' target='_blank' rel='noopener'>RuneLite</a>
+                                </li>
+                        </ul>
+                    </div>
+                    <div class='home-nav__box'>
+                        <h3 class='home-nav__title'>Account</h3>
+                        <ul class='home-nav__list'>
+                            <li>
+                                <a class='home-nav__link home-nav__link--member' id='osnav-member' data-test='osnav-member' href='https://osrs.runescape.com/membership'>Become a Member</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--bonds' id='osnav-bonds' data-test='osnav-bonds' href='https://www.runescape.com/oldschool/bonds'>Old School Bonds</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--account' id='osnav-account' data-test='osnav-account' href='https://account.jagex.com/en-GB/manage/profile'>Account Settings</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--authenticator' id='osnav-authenticator' data-test='osnav-authenticator' href='https://www.runescape.com/authenticator'>Enable Authenticator</a>
+                            </li>
+                            <li>
+                                <a class='home-nav__link home-nav__link--support' id='osnav-support' data-test='osnav-support' href='https://support.runescape.com' target='_blank'>Support</a>
+                            </li>
+                        </ul>
+                    </div>
+				</nav>
+                <div class='home-buttons'>
+                    <a class='home-button' href='https://oldschool.runescape.com/play'>
+                        <div class='home-button__content'>Try Free</div>
+                    </a>
+                    <a class='home-button' href='https://osrs.runescape.com/membership'>
+                        <div class='home-button__content'>Become a Member</div>
+                    </a>
+                    <a class='home-button' href='https://secure.runescape.com/m=hiscore_oldschool/overall'>
+                        <div class='home-button__content'>Visit HiScores</div>
+                    </a>
+                    <a class='home-buttons__foot-link' id='osnav-manualselect' data-test='osnav-manualworldselect' href='https://oldschool.runescape.com/slu'>Manually select world</a>
+                    <a class="home-promo-banner" href="https://osrs.game/Wyrmscraig-Out-Now">
+                        <img
+                            src="https://www.runescape.com/img/rsp777/wyrmscraig_banner_outnow_oldschool.png"
+                            class="home-promo-banner__image"
+                        />
+                    </a>
+                </div>
+			</div>
+			<section class='content'>
+				<h1 class='home-main-title'>Welcome to Old School RuneScape!</h1>
+                <p class='content__copy'>Relive the challenging levelling system and risk-it-all PvP of the biggest retro styled MMO. Play with millions of other players in this piece of online gaming heritage where the community controls the development so the game is truly what you want it to be!</p>
+				<h2 class='content__title content__title--news'>News & Updates</h2>
+                        <article class='news-article '>
+                            <figure class='news-article__figure'>
+                                <a class='news-article__figure-link' href="https://secure.runescape.com/m=news/the-official-osrs-podcast-episode-16-with-mod-nin?oldschool=1" id='news-article-fig-1' data-test='news-article-fig-1'>
+                                    <img class='news-article__figure-img' src="https://cdn.runescape.com/assets/img/external/oldschool/2026/Newsposts/2026-07-31/OSP-EP16-Thumbnail-Min.jpg" alt="Season 2 continues today, and this time we're joined by Mod Nin for our first ever engine developer appearance on the podcast!" title="Season 2 continues today, and this time we're joined by Mod Nin for our first ever engine developer appearance on the podcast!" id='news-article-img-1' data-test='news-article-img-1'/>
+                                </a>
+                            </figure>
+                            <div class='news-article__details'>
+                                <h3 class='news-article__title'><a class='secondary-link' href="https://secure.runescape.com/m=news/the-official-osrs-podcast-episode-16-with-mod-nin?oldschool=1">The Official OSRS Podcast Episode 16 With Mod Nin</a></h3>
+                                <span class='news-article__sub'>Community <time datetime='2026-08-02' class='news-article__time'>02 August 2026</time></span>
+                                <p class='news-article__summary'>Season 2 continues today, and this time we're joined by Mod Nin for our first ever engine developer appearance on the podcast! <a class='secondary-link news-article__read-more' href="https://secure.runescape.com/m=news/the-official-osrs-podcast-episode-16-with-mod-nin?oldschool=1" id='news-article-link-1' data-test='news-article-link-1'>Read More...</a></p>
+                            </div>
+                        </article>
+                        <article class='news-article '>
+                            <figure class='news-article__figure'>
+                                <a class='news-article__figure-link' href="https://secure.runescape.com/m=news/the-fractured-archive---rewards-poll-blog?oldschool=1" id='news-article-fig-2' data-test='news-article-fig-2'>
+                                    <img class='news-article__figure-img' src="https://cdn.runescape.com/assets/img/external/oldschool/2026/Newsposts/2026-07-30-cool/thumb.png" alt="It's nearly time to have your say on Old School's fourth set of raid rewards!" title="It's nearly time to have your say on Old School's fourth set of raid rewards!" id='news-article-img-2' data-test='news-article-img-2'/>
+                                </a>
+                            </figure>
+                            <div class='news-article__details'>
+                                <h3 class='news-article__title'><a class='secondary-link' href="https://secure.runescape.com/m=news/the-fractured-archive---rewards-poll-blog?oldschool=1">The Fractured Archive - Rewards Poll Blog</a></h3>
+                                <span class='news-article__sub'>Future Updates <time datetime='2026-07-30' class='news-article__time'>30 July 2026</time></span>
+                                <p class='news-article__summary'>It's nearly time to have your say on Old School's fourth set of raid rewards! <a class='secondary-link news-article__read-more' href="https://secure.runescape.com/m=news/the-fractured-archive---rewards-poll-blog?oldschool=1" id='news-article-link-2' data-test='news-article-link-2'>Read More...</a></p>
+                            </div>
+                        </article>
+                        <article class='news-article '>
+                            <figure class='news-article__figure'>
+                                <a class='news-article__figure-link' href="https://secure.runescape.com/m=news/osrs-tcg---the-hottest-new-runelite-plugin?oldschool=1" id='news-article-fig-3' data-test='news-article-fig-3'>
+                                    <img class='news-article__figure-img' src="https://cdn.runescape.com/assets/img/external/oldschool/2026/Newsposts/2026-07-30/Thumbnail-TCG.jpg" alt="Cards, packs, foils, a new restricted game mode? What's going on with the TCG plugin?" title="Cards, packs, foils, a new restricted game mode? What's going on with the TCG plugin?" id='news-article-img-3' data-test='news-article-img-3'/>
+                                </a>
+                            </figure>
+                            <div class='news-article__details'>
+                                <h3 class='news-article__title'><a class='secondary-link' href="https://secure.runescape.com/m=news/osrs-tcg---the-hottest-new-runelite-plugin?oldschool=1">OSRS TCG - The Hottest New RuneLite Plugin</a></h3>
+                                <span class='news-article__sub'>Community <time datetime='2026-07-30' class='news-article__time'>30 July 2026</time></span>
+                                <p class='news-article__summary'>Cards, packs, foils, a new restricted game mode? What's going on with the TCG plugin? <a class='secondary-link news-article__read-more' href="https://secure.runescape.com/m=news/osrs-tcg---the-hottest-new-runelite-plugin?oldschool=1" id='news-article-link-3' data-test='news-article-link-3'>Read More...</a></p>
+                            </div>
+                        </article>
+                        <article class='news-article '>
+                            <figure class='news-article__figure'>
+                                <a class='news-article__figure-link' href="https://secure.runescape.com/m=news/wyrmscraig-is-out-today?oldschool=1" id='news-article-fig-4' data-test='news-article-fig-4'>
+                                    <img class='news-article__figure-img' src="https://cdn.runescape.com/assets/img/external/oldschool/2026/Newsposts/2026-07-28/OutNow.jpg" alt="Welcome to Wyrmscraig, the winner of our Player-Designed Island competition!" title="Welcome to Wyrmscraig, the winner of our Player-Designed Island competition!" id='news-article-img-4' data-test='news-article-img-4'/>
+                                </a>
+                            </figure>
+                            <div class='news-article__details'>
+                                <h3 class='news-article__title'><a class='secondary-link' href="https://secure.runescape.com/m=news/wyrmscraig-is-out-today?oldschool=1">Wyrmscraig Is Out Today!</a></h3>
+                                <span class='news-article__sub'>Game Updates <time datetime='2026-07-29' class='news-article__time'>29 July 2026</time></span>
+                                <p class='news-article__summary'>Welcome to Wyrmscraig, the winner of our Player-Designed Island competition! <a class='secondary-link news-article__read-more' href="https://secure.runescape.com/m=news/wyrmscraig-is-out-today?oldschool=1" id='news-article-link-4' data-test='news-article-link-4'>Read More...</a></p>
+                            </div>
+                        </article>
+                        <article class='news-article '>
+                            <figure class='news-article__figure'>
+                                <a class='news-article__figure-link' href="https://secure.runescape.com/m=news/meet-mortimer-your-newest-slayer-master?oldschool=1" id='news-article-fig-5' data-test='news-article-fig-5'>
+                                    <img class='news-article__figure-img' src="https://cdn.runescape.com/assets/img/external/oldschool/2026/Newsposts/2026-07-24/TH21.png" alt="Let's take a closer look at Mortimer before Wyrmscraig launches on July 29!" title="Let's take a closer look at Mortimer before Wyrmscraig launches on July 29!" id='news-article-img-5' data-test='news-article-img-5'/>
+                                </a>
+                            </figure>
+                            <div class='news-article__details'>
+                                <h3 class='news-article__title'><a class='secondary-link' href="https://secure.runescape.com/m=news/meet-mortimer-your-newest-slayer-master?oldschool=1">Meet Mortimer: Your Newest Slayer Master</a></h3>
+                                <span class='news-article__sub'>Behind The Scenes <time datetime='2026-07-27' class='news-article__time'>27 July 2026</time></span>
+                                <p class='news-article__summary'>Let's take a closer look at Mortimer before Wyrmscraig launches on July 29! <a class='secondary-link news-article__read-more' href="https://secure.runescape.com/m=news/meet-mortimer-your-newest-slayer-master?oldschool=1" id='news-article-link-5' data-test='news-article-link-5'>Read More...</a></p>
+                            </div>
+                        </article>
+                    <p class='content__copy content__copy--center'>You can also follow our <a id='home-copy-twitter' data-test='oshome-twitter' class='secondary-link' href='https://www.twitter.com/OldSchoolRS' target='_blank' rel="noopener">Twitter</a> feed for the latest news &amp; updates or view older posts in our <a id='home-copy-news' data-test='oshome-news-archive' class='secondary-link' href='https://secure.runescape.com/m=news/archive?oldschool=1'>news archive</a>.</p>
+			</section>
+		</main>
+    </div>
+    <script src='https://secure.adnxs.com/seg?add=642422&amp;t=1' type='text/javascript'></script>
+	<footer class='footer'>
+		<a id='footer-jagex-logo' class='footer__jagex' href='https://www.jagex.com/en-GB/' target='_blank'><img class='footer__jagex-img' src='https://www.runescape.com/img/responsive/common/logos/jagex-gold.svg?1' title="Jagex" alt="Jagex" /></a>
+		<p>This website and its contents are copyright &copy; 1999 - 2026 Jagex Games Ltd, 220 Science Park, Cambridge, CB4 0WA, United Kingdom.</p>
+        <p>Use of this website is subject to our <a id='footer-terms' href='https://legal.jagex.com/docs/terms' target='_blank'>Terms &amp; Conditions</a> and <a id='footer-privacy' href='https://legal.jagex.com/docs/policies' target='_blank'>Privacy Policy</a></p>
+		<p>
+			<a id='footer-rules' target='_blank' href='https://legal.jagex.com/docs/rules'>Rules of Old School RuneScape</a> | <a id='footer-cookies' target='_blank' href='https://play.runescape.com/cookies'>Cookie Policy</a> |
+			<a id='footer-manage-cookies' href=''>Manage Cookies</a> | <a id='footer-rights' target='_blank' href='https://legal.jagex.com/docs/policies/privacy/exercising-your-rights' title="Jagex does not sell personal information as the term 'sell' is commonly understood. We do allow service providers to use your personal information for advertising, marketing, and analytics. Please click this link for more information on how to opt out in our Privacy Policy.">Do Not Sell Or Share My Personal Information</a>
+		</p>
+        <a id='footer-rss' class='footer__rss' href='https://secure.runescape.com/m=news/latest_news.rss?oldschool=true' target='_blank'>RSS Feed</a>
+    <p class='footer__disclaimer' id='osrs-disclaimer'>* The <span class='footer__external-links'>external links</span> provided in this section are collected to give you an easy way of engaging with some of the most popular outposts of the OSRS community. Jagex is not responsible for the maintenance and safety of content produced and hosted by third parties and any use of third-party sites is at your own risk.</p>
+        <div class='footer__pegi m-pegi'>
+            <div class='m-pegi__icons'>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI 16" src='https://www.runescape.com/img/responsive/common/icons/pegi-16.svg' class='m-pegi__age' width='53.313' height='65' />
+                </a>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI icon to represent drug use" title="The game refers to or depicts the use of illegal drugs, alcohol or tobacco." src='https://www.runescape.com/img/responsive/common/icons/pegi-drugs.svg' class='m-pegi__descriptor' width='55' height='55' />
+                </a>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI icon to represent in-game purchases" title="The game offers players the option to purchase digital goods or services with real-world currency." src='https://www.runescape.com/img/responsive/common/icons/pegi-ingame-purchases.svg' class='m-pegi__descriptor' width='55' height='55' />
+                </a>
+            </div>
+            <p class='m-pegi__strap'>In-game Purchases (Includes Random Items)</p>
+        </div>
+		<script>
+			const manageCookieLink = document.querySelector("#footer-manage-cookies");
+			manageCookieLink.addEventListener("click", function onclick(event) {
+				event.preventDefault();
+				window.athena("consent", "triggerBanner");
+			});
+		</script>
+	</footer>
+
+	<script>
+		pageLocation = 'https://www.runescape.com/';
+		document.domain = 'runescape.com';
+		var baseURL = 'https://www.runescape.com', homeRedirect = 'https://oldschool.runescape.com/', JXGLOBAL = {};
+		JXGLOBAL.client = [{
+			'platform': 'Windows_x86',
+			'filename': 'oldschool.msi',
+			'version': '1.4.3',
+			'size': '23'
+		},{
+			'platform': 'OSX_x86',
+			'filename': 'runescape.dmg',
+			'version': '1.4.3',
+			'size': '2.5'
+		}];
+
+        var RESPONSIVE = RESPONSIVE || {};
+        RESPONSIVE.constant = RESPONSIVE.constant || {};
+            RESPONSIVE.constant.user = {
+                language: 0,
+                isLoggedIn: 0
+            };
+    </script>
+		<script src='https://www.runescape.com/js/c/responsive/vendor-168.js'></script>
+	<script src='https://www.runescape.com/js/c/rs3/modernizr_3_0_0_min-169.js'></script>
+    <script src='https://www.runescape.com/js/osrs/plugins-155.js'></script>
+	<script src='https://www.runescape.com/js/osrs/gtm-155.js' data-ot-ignore></script>
+	<script src='https://www.runescape.com/js/jagex_global-101.js'></script>
+    <script src='https://www.runescape.com/js/c/os/functions-155.js' async defer></script>
+		</div>
+		<script>var bStyle = document.getElementById('bConHide'); if (bStyle) bStyle.parentNode.removeChild(bStyle);</script>
+    <script>(function(){function c(){var b=a.contentDocument||(a.contentWindow&&a.contentWindow.document);if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a2602bdc4856759e',t:'MTc4NTg3Mzg2OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/tests/fixtures/slu.html
+++ b/tests/fixtures/slu.html
@@ -1,0 +1,3135 @@
+<!doctype html>
+    <!--[if lt IE 7]><html class='no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7' lang='en'><![endif]-->
+    <!--[if (IE 7)&!(IEMobile)]><html class='no-js lt-ie10 lt-ie9 lt-ie8' lang='en'><![endif]-->
+    <!--[if (IE 8)&!(IEMobile)]><html class='no-js lt-ie10 lt-ie9' lang='en'><![endif]-->
+    <!--[if (IE 9)&!(IEMobile)]><html class='no-js lt-ie10' lang='en'><![endif]-->
+    <!--[if gt IE 9]><!--><!-- x --> <html class='no-js no-autoplay' lang='en'> <!--<![endif]-->
+<head>
+    <title>Play Old School RuneScape - World Server List</title>
+		<meta name='description' content="Challenging levelling system and risk-it-all PvP. Experience the world of Old School RuneScape."/>
+    <meta name='author' content='Jagex'/>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <link rel='dns-prefetch' href='//www.google-analytics.com' />
+    <link rel='dns-prefetch' href='//ajax.googleapis.com' />
+    <link rel='dns-prefetch' href='//connect.facebook.net' />
+    <link href='https://www.runescape.com/css/c/oldschool-128.css' rel='stylesheet' />
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-16x16.png?1' sizes='16x16' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-32x32.png?1' sizes='32x32' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-96x96.png?1' sizes='96x96' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-128x128.png?1' sizes='128x128' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-144x144.png?1' sizes='144x144' type='image/png'>
+	<link rel='icon' href='https://www.runescape.com/img/rsp777/os-favicon-196x196.png?1' sizes='196x196' type='image/png'>
+    <link rel='shortcut icon' href='https://www.runescape.com/img/rsp777/favicon.ico?1' sizes="64x64">
+    <link rel='apple-touch-icon' href='https://www.runescape.com/img/rsp777/os-favicon.png?1'>
+	<link rel='apple-touch-icon-precomposed' sizes='57x57' href='https://www.runescape.com/img/rsp777/apple-touch-icon-57x57.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='114x114' href='https://www.runescape.com/img/rsp777/apple-touch-icon-114x114.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='72x72' href='https://www.runescape.com/img/rsp777/apple-touch-icon-72x72.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='144x144' href='https://www.runescape.com/img/rsp777/apple-touch-icon-144x144.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='60x60' href='https://www.runescape.com/img/rsp777/apple-touch-icon-60x60.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='120x120' href='https://www.runescape.com/img/rsp777/apple-touch-icon-120x120.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='76x76' href='https://www.runescape.com/img/rsp777/apple-touch-icon-76x76.png?1' />
+	<link rel='apple-touch-icon-precomposed' sizes='152x152' href='https://www.runescape.com/img/rsp777/apple-touch-icon-152x152.png?1' />
+	<meta name='application-name' content="Old School RuneScape Website"/>
+	<meta name='msapplication-TileColor' content='#1317FB' />
+	<meta name='msapplication-TileImage' content='https://www.runescape.com/img/rsp777/mstile-144x144.png?1' />
+	<meta name='msapplication-square70x70logo' content='https://www.runescape.com/img/rsp777/mstile-70x70.png?1' />
+	<meta name='msapplication-square150x150logo' content='https://www.runescape.com/img/rsp777/mstile-150x150.png?1' />
+	<meta name='msapplication-wide310x150logo' content='https://www.runescape.com/img/rsp777/mstile-310x150.png?1' />
+	<meta name='msapplication-square310x310logo' content='https://www.runescape.com/img/rsp777/mstile-310x310.png?1' />
+
+		<meta property='og:title' content="Play Old School RuneScape - World Server List" />
+		<meta property='og:site_name' content='Old School RuneScape' />
+    <meta property='og:image' content='https://www.runescape.com/img/rsp777/social-share-fb.jpg?1' />
+    <meta property='og:image' content='https://www.runescape.com/img/rsp777/os-og-image.jpg?1' />
+    <meta property='og:url' content='https://oldschool.runescape.com/slu' />
+		<meta property='og:description' content="Challenging levelling system and risk-it-all PvP. Experience the world of Old School RuneScape." />
+	<meta name='twitter:card' content='summary_large_image'/>
+    <meta name='twitter:domain' content='Oldschool.RuneScape.com'>
+    <meta name='twitter:url' content='https://oldschool.runescape.com/slu'>
+		<meta name='twitter:title' content="Play Old School RuneScape - World Server List">
+		<meta name='twitter:description' content="Challenging levelling system and risk-it-all PvP. Experience the world of Old School RuneScape.">
+    <meta name='twitter:image:src' content='https://www.runescape.com/img/rsp777/social-share.jpg?1'>
+    <meta name='twitter:site' content='@OldSchoolRS'>
+    <meta name='google-site-verification' content='pUwl5KYHKSZ6tbbgsR2wYNv1kbVmsYral3iFmijHTWM' />
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag("consent", "default", {
+            ad_storage: "denied",
+            analytics_storage: "denied",
+            functionality_storage: "denied",
+            personalization_storage: "denied",
+            ad_personalization: "denied",
+            ad_user_data: "denied",
+            security_storage: "granted",
+            wait_for_update: 1500,
+        });
+        gtag("set", "ads_data_redaction", true);
+        (function(){
+            function hasGroup(id) {
+                return typeof window.OnetrustActiveGroups === "string" &&
+                    window.OnetrustActiveGroups.indexOf(id) > -1;
+            }
+            function syncGCM(){
+                if (typeof window.gtag !== "function") return;
+                if (typeof window.OnetrustActiveGroups !== "string") return;
+                gtag("consent", "update", {
+                    ad_personalization:         hasGroup("C0004") ? "granted" : "denied",
+                    ad_storage:                 hasGroup("C0004") ? "granted" : "denied",
+                    ad_user_data:               hasGroup("C0004") ? "granted" : "denied",
+                    analytics_storage:          hasGroup("C0002") ? "granted" : "denied",
+                    functionality_storage:      hasGroup("C0003") ? "granted" : "denied",
+                    personalization_storage:    hasGroup("C0003") ? "granted" : "denied",
+                    security_storage:           "granted",
+                });
+                dataLayer.push({event: "cookie_consent_update", onetrust_groups: window.OnetrustActiveGroups});
+            }
+            window.addEventListener("OneTrustGroupsUpdated", syncGCM, false);
+            syncGCM();
+        })();
+    </script>
+    <script src='https://cdn-ukwest.onetrust.com/consent/019b25be-0577-738e-8af0-4b232af181c1/OtAutoBlock.js'></script>
+    <script data-ot-ignore>
+        !(function (w, d, s, u) {
+            w._athena = w._athena || {};
+            w._athena.queue = w._athena.queue || [];
+
+            function athena(component, method, callback, ...args) {
+                const call = { component, method, callback, args };
+
+                if (typeof w._athena.direct === "function") {
+                    w._athena.direct(call);
+                    return;
+                }
+
+                w._athena.queue.push(call);
+            }
+
+            w.athena = w.athena || athena;
+
+            var f = d.getElementsByTagName(s)[0];
+            var js = d.createElement(s);
+            js.src = u;
+            js.async = true;
+            js.setAttribute("data-consent-domain", "runescape.com");
+            js.setAttribute("data-environment", "production");
+            js.setAttribute("data-acquisition-product-id", "com.runescape.oldschool");
+            js.setAttribute("data-acquisition-domain", "runescape.com");
+            js.setAttribute("data-ot-ignore", "true");
+            f.parentNode.insertBefore(js, f);
+        })(window, document, "script", 'https://athena.runescape.com/athena.0.latest.js');
+    </script>
+	<link rel='canonical' href='https://oldschool.runescape.com/slu' />
+    <script type="speculationrules">
+        {
+            "prerender": [
+                {
+                    "where": {
+                        "and": [
+                            { "href_matches": "/*" },
+                            { "not": { "href_matches": "/logout" }}
+                        ]
+                    },
+                    "eagerness": "moderate"
+                },
+                {
+                    "where": {
+                        "and": [
+                            { "selector_matches": ".a-button" },
+                            { "not": { "selector_matches": ".a-button--style-hollow" }},
+                            { "not": { "href_matches": "/logout" }}
+                        ]
+                    }
+                }
+            ]
+        }
+    </script>
+    <style>
+        @view-transition {
+            navigation: auto;
+        }
+    </style>
+		<script>var bStyle = document.createElement('style'); bStyle.type = 'text/css'; bStyle.setAttribute('id', 'bConHide'); bStyle.appendChild(document.createTextNode('body { opacity: 0!important; filter: alpha(opacity=0)!important; background: none!important; }')); document.head.appendChild(bStyle);</script>
+    </head>
+	<body id='os-slu' class='os-slu '>
+		<div class='page-wrap'>
+    	<span class='login-box'><a href='https://secure.runescape.com/m=weblogin/loginform?theme=oldschool&amp;mod=oldschool&amp;ssl=1&amp;dest=slu' id='showOsLogin' class='login-box__login-link'>Log in</a></span>
+    <header class='banner'>
+        <div class='banner__options'>
+			<h1 class='banner__title'>Select a world</h1>
+			<a id='banner-home' class='banner__home' href='https://oldschool.runescape.com/'>Home</a>
+        </div>
+    </header>
+    <div class='contents'>
+        <main class='main'>
+            <p class='player-count'>There are currently 131,881 people playing!</p>
+            <section class="slu-quick">
+                <h2 class="slu-quick__title">Quick select (Recommended)</h2>
+                <p class="slu-quick__copy">This will choose the best world for you based on available space and your location.</p>
+        <a class='home-button home-button--slu home-button--slu-free' id='free-world' href='https://oldschool.runescape.com/game?world=436'>
+            <span class='home-button__action'>Choose best free world for me</span><span class='home-button__name'>(Old School 136)</span>
+        </a>
+        <a class='home-button home-button--slu home-button--slu-mem' id='member-world' href='https://oldschool.runescape.com/game?world=320'>
+            <span class='home-button__action'>Choose best members world for me</span><span class='home-button__name'>(Old School 20)</span>
+        </a>
+            </section>
+            <section class="adv-select">
+                <h2 class="adv-select__title">Advanced select (For experienced players)</h2>
+                <p class="adv-select__copy">If there is a particular world that you want to use, choose it by clicking on its name.</p>
+                <p class="adv-select__copy">You can reorder the list by clicking on the arrows.</p>
+                <table class="server-list">
+                    <thead class="server-list__head">
+                        <tr class="server-list__head-row">
+                            <th class="server-list__head-cell">
+    <a href='slu?order=wMLPA' class='table-sort table-sort--asc'>ascending</a>
+    <a href='slu?order=WMLPA' class='table-sort table-sort--dsc'>descending</a>
+                                <span class="server-list__head-copy">World</span>
+                            </th>
+                            <th class="server-list__head-cell">
+    <a href='slu?order=pMLWA' class='table-sort table-sort--asc'>ascending</a>
+    <a href='slu?order=PMLWA' class='table-sort table-sort--dsc'>descending</a>
+                                <span class="server-list__head-copy">Players</span>
+                            </th>
+                            <th class="server-list__head-cell">
+    <a href='slu?order=lMPWA' class='table-sort table-sort--asc'>ascending</a>
+    <a href='slu?order=LMPWA' class='table-sort table-sort--dsc'>descending</a>
+                                <span class="server-list__head-copy">Location</span>
+                            </th>
+                            <th class="server-list__head-cell">
+    <a href='slu?order=mLPWA' class='table-sort table-sort--asc'>ascending</a>
+    <a href='slu?order=MLPWA' class='table-sort table-sort--dsc table-sort--current'>descending</a>
+                                <span class="server-list__head-copy">Type</span>
+                            </th>
+                            <th class="server-list__head-cell">
+    <a href='slu?order=aMLPW' class='table-sort table-sort--asc'>ascending</a>
+    <a href='slu?order=AMLPW' class='table-sort table-sort--dsc'>descending</a>
+                                <span class="server-list__head-copy">Activity</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class='server-list__body'>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-393' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=393'>Old School 93</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>69 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-468' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=468'>Old School 168</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>90 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--pvp'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-577' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=577'>Old School 277</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>90 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>PvP World - Free</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-483' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=483'>Old School 183</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>114 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-469' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=469'>Old School 169</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>182 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>LMS Casual</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-417' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=417'>Old School 117</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>204 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-301' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=301'>Old School 1</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1086 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Trade - Free</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-413' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=413'>Old School 113</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>68 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-414' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=414'>Old School 114</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>71 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-553' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=553'>Old School 253</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>76 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-554' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=554'>Old School 254</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>95 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-552' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=552'>Old School 252</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>99 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-555' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=555'>Old School 255</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>107 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-397' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=397'>Old School 97</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>110 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-454' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=454'>Old School 154</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>122 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-451' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=451'>Old School 151</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>126 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-399' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=399'>Old School 99</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>128 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-453' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=453'>Old School 153</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>130 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-455' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=455'>Old School 155</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>135 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-452' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=452'>Old School 152</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>138 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-384' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=384'>Old School 84</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>145 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-398' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=398'>Old School 98</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>147 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-383' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=383'>Old School 83</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>172 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Castle Wars - Free</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-456' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=456'>Old School 156</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>174 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-335' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=335'>Old School 35</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>229 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-419' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=419'>Old School 119</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>75 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-432' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=432'>Old School 132</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>93 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-436' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=436'>Old School 136</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>132 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-435' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=435'>Old School 135</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>133 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-437' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=437'>Old School 137</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>134 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-431' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=431'>Old School 131</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>141 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-418' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=418'>Old School 118</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>147 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-433' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=433'>Old School 133</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>155 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-430' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=430'>Old School 130</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>188 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-434' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=434'>Old School 134</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>225 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-565' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=565'>Old School 265</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>0 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Fresh Start</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-372' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=372'>Old School 72</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>80 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-497' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=497'>Old School 197</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>86 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Clan Recruitment</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-381' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=381'>Old School 81</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>103 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-499' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=499'>Old School 199</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>112 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-498' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=498'>Old School 198</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>115 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-379' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=379'>Old School 79</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>139 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-326' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=326'>Old School 26</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>210 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>LMS Casual</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-380' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=380'>Old School 80</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>219 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-316' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=316'>Old School 16</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>238 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Wilderness PK - Free</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-382' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=382'>Old School 82</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>360 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-308' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=308'>Old School 8</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>709 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>Wilderness PK - Free</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-530' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=530'>Old School 230</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>50 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-427' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=427'>Old School 127</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>61 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-571' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=571'>Old School 271</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>68 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-537' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=537'>Old School 237</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>84 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-692' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=692'>Old School 392</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>113 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--BR'>Brazil</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-660' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=660'>Old School 360</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>83 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--SG'>Singapore</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-698' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=698'>Old School 398</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>84 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--JP'>Japan</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-667' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=667'>Old School 367</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>78 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--ZA'>South Africa</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Free</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-576' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=576'>Old School 276</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>4 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Speedrunning World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-578' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=578'>Old School 278</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>49 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (US)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-345' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=345'>Old School 45</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>115 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Deadman - Permanent</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-474' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=474'>Old School 174</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>352 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>High Risk World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-471' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=471'>Old School 171</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>403 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Sorceress's Garden</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-618' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=618'>Old School 318</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>412 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2350 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-574' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=574'>Old School 274</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>413 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-575' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=575'>Old School 275</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>425 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-573' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=573'>Old School 273</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>432 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Royal Titans</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-479' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=479'>Old School 179</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>448 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-496' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=496'>Old School 196</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>448 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-477' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=477'>Old School 177</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>454 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Clan Recruitment</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-481' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=481'>Old School 181</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>456 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nex FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-476' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=476'>Old School 176</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>459 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-473' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=473'>Old School 173</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>477 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-487' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=487'>Old School 187</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>478 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-612' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=612'>Old School 312</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>480 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-485' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=485'>Old School 185</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>488 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-491' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=491'>Old School 191</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>490 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Burthorpe Games Room</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-611' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=611'>Old School 311</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>491 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-470' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=470'>Old School 170</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>494 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Mastering Mixology</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-475' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=475'>Old School 175</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>502 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-488' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=488'>Old School 188</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>502 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-482' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=482'>Old School 182</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>503 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-490' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=490'>Old School 190</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>512 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-467' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=467'>Old School 167</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>514 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-415' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=415'>Old School 115</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>515 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2200 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-493' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=493'>Old School 193</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>517 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Pyramid Plunder</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-614' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=614'>Old School 314</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>522 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-394' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=394'>Old School 94</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>523 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Yama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-486' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=486'>Old School 186</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>525 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-609' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=609'>Old School 309</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>529 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-353' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=353'>Old School 53</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>531 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1250 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-613' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=613'>Old School 313</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>531 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-615' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=615'>Old School 315</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>534 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-402' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=402'>Old School 102</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>535 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wintertodt</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-495' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=495'>Old School 195</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>545 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-322' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=322'>Old School 22</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>557 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Clan Wars - Free-for-all</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-489' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=489'>Old School 189</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>557 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-472' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=472'>Old School 172</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>558 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-492' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=492'>Old School 192</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>564 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-494' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=494'>Old School 194</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>565 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-337' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=337'>Old School 37</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>582 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nightmare of Ashihama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-480' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=480'>Old School 180</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>588 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Ourania Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-484' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=484'>Old School 184</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>589 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-369' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=369'>Old School 69</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>591 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wilderness PK - Members</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-403' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=403'>Old School 103</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>599 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-385' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=385'>Old School 85</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>604 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Brimhaven Agility</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-377' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=377'>Old School 77</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>610 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Mort'ton temple, Rat Pits</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-610' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=610'>Old School 310</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>617 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-314' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=314'>Old School 14</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>625 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Brimhaven Agility Arena</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-361' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=361'>Old School 61</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>627 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2000 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-329' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=329'>Old School 29</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>660 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tombs of Amascut</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-362' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=362'>Old School 62</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>666 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>TzHaar Fight Pit</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-416' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=416'>Old School 116</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>666 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-354' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=354'>Old School 54</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>688 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Castle Wars 2</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-404' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=404'>Old School 104</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>717 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-321' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=321'>Old School 21</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>719 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Sulliuscep cutting</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-370' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=370'>Old School 70</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>731 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Fishing Trawler</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-346' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=346'>Old School 46</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>740 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Agility Training</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-478' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=478'>Old School 178</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>797 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-386' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=386'>Old School 86</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>809 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-305' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=305'>Old School 5</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>862 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Falador Party Room</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-597' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=597'>Old School 297</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1695 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Salvaging</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-330' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=330'>Old School 30</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1928 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>House Party, Gilded Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-596' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=596'>Old School 296</a>
+                                    </td>
+                                    <td class='server-list__row-cell'></td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Salvaging</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-549' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=549'>Old School 249</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>0 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Speedrunning World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--pvp server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-548' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=548'>Old School 248</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>56 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP World - High Risk</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-627' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=627'>Old School 327</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>316 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2350 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-557' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=557'>Old School 257</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>342 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-551' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=551'>Old School 251</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>343 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-447' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=447'>Old School 147</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>350 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1250 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-556' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=556'>Old School 256</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>355 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-582' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=582'>Old School 282</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>364 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-448' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=448'>Old School 148</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>386 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-626' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=626'>Old School 326</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>390 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-406' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=406'>Old School 106</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>391 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-624' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=624'>Old School 324</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>398 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-550' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=550'>Old School 250</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>400 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-450' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=450'>Old School 150</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>404 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2200 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-625' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=625'>Old School 325</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>405 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-396' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=396'>Old School 96</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>416 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2000 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-405' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=405'>Old School 105</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>434 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-466' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=466'>Old School 166</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>436 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-462' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=462'>Old School 162</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>446 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-459' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=459'>Old School 159</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>455 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-458' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=458'>Old School 158</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>456 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-461' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=461'>Old School 161</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>468 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-457' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=457'>Old School 157</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>481 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-449' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=449'>Old School 149</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>499 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-359' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=359'>Old School 59</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>523 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-368' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=368'>Old School 68</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>525 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-336' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=336'>Old School 36</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>528 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>ToA FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-463' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=463'>Old School 163</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>557 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tempoross</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-375' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=375'>Old School 75</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>571 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Zalcano</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-312' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=312'>Old School 12</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>573 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Group Skilling</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-328' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=328'>Old School 28</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>574 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Royal Titans</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-395' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=395'>Old School 95</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>582 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-376' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=376'>Old School 76</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>595 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Theatre of Blood</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-367' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=367'>Old School 67</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>600 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-351' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=351'>Old School 51</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>602 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-327' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=327'>Old School 27</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>608 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Ourania Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-311' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=311'>Old School 11</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>650 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wintertodt</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-343' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=343'>Old School 43</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>675 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Yama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-352' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=352'>Old School 52</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>679 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-360' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=360'>Old School 60</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>691 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-465' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=465'>Old School 165</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>712 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>House Party, Gilded Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-304' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=304'>Old School 4</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>771 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Trouble Brewing</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-464' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=464'>Old School 164</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>892 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-303' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=303'>Old School 3</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>899 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-344' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=344'>Old School 44</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>940 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--DE'>Germany</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Pest Control</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-423' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=423'>Old School 123</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>0 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Fresh Start</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-540' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=540'>Old School 240</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>0 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Speedrunning World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--pvp server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-539' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=539'>Old School 239</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>217 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-544' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=544'>Old School 244</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>252 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-608' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=608'>Old School 308</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>257 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2350 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-545' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=545'>Old School 245</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>263 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-547' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=547'>Old School 247</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>263 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-541' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=541'>Old School 241</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>270 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-607' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=607'>Old School 307</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>273 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2200 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-542' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=542'>Old School 242</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>276 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-599' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=599'>Old School 299</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>278 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-546' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=546'>Old School 246</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>280 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-604' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=604'>Old School 304</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>286 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-538' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=538'>Old School 238</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>288 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-601' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=601'>Old School 301</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>304 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-348' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=348'>Old School 48</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>307 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-543' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=543'>Old School 243</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>313 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-445' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=445'>Old School 145</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>319 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-603' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=603'>Old School 303</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>331 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-602' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=602'>Old School 302</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>334 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-606' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=606'>Old School 306</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>341 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-429' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=429'>Old School 129</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>343 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1250 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-600' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=600'>Old School 300</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>351 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-442' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=442'>Old School 142</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>361 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-378' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=378'>Old School 78</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>376 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Zalcano</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-411' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=411'>Old School 111</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>387 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-439' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=439'>Old School 139</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>387 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-443' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=443'>Old School 143</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>400 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-441' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=441'>Old School 141</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>402 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-338' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=338'>Old School 38</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>403 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>ToA FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-428' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=428'>Old School 128</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>412 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2000 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-323' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=323'>Old School 23</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>429 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Volcanic Mine</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-340' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=340'>Old School 40</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>437 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Varlamore PvM</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-315' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=315'>Old School 15</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>440 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Fishing Trawler</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-347' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=347'>Old School 47</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>445 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-324' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=324'>Old School 24</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>446 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Royal Titans</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-438' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=438'>Old School 138</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>450 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-410' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=410'>Old School 110</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>452 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-440' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=440'>Old School 140</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>454 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-374' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=374'>Old School 74</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>455 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Theatre of Blood</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-446' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=446'>Old School 146</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>461 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Role-playing</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-332' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=332'>Old School 32</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>464 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nex FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-357' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=357'>Old School 57</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>498 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-331' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=331'>Old School 31</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>509 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tombs of Amascut</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-339' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=339'>Old School 39</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>516 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Yama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-320' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=320'>Old School 20</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>544 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Soul Wars</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-313' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=313'>Old School 13</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>558 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Group Skilling</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-355' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=355'>Old School 55</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>625 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-421' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=421'>Old School 121</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>632 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-306' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=306'>Old School 6</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>680 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Barbarian Assault</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-356' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=356'>Old School 56</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>715 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-307' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=307'>Old School 7</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>824 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wintertodt</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-420' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=420'>Old School 120</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1109 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-409' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=409'>Old School 109</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1273 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-422' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=422'>Old School 122</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1283 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tempoross</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-444' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=444'>Old School 144</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1952 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--US'>United States</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-502' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=502'>Old School 202</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Speedrunning World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-558' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=558'>Old School 258</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>48 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (UK)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-623' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=623'>Old School 323</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>303 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2350 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-363' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=363'>Old School 63</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>306 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2200 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-365' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=365'>Old School 65</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>324 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>High Risk World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-564' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=564'>Old School 264</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>340 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-566' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=566'>Old School 266</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>347 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-563' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=563'>Old School 263</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>350 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-501' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=501'>Old School 201</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>356 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-562' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=562'>Old School 262</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>358 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-522' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=522'>Old School 222</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>360 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-503' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=503'>Old School 203</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>361 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-619' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=619'>Old School 319</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>367 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-366' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=366'>Old School 66</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>375 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-504' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=504'>Old School 204</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>383 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-371' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=371'>Old School 71</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>384 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-523' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=523'>Old School 223</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>384 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nex FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-506' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=506'>Old School 206</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>385 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (Legacy Duels)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-519' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=519'>Old School 219</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>391 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-408' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=408'>Old School 108</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>392 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-622' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=622'>Old School 322</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>395 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-505' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=505'>Old School 205</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>411 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nex FFA</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-507' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=507'>Old School 207</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>416 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-364' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=364'>Old School 64</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>419 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1250 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-512' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=512'>Old School 212</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>425 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>House Party, Gilded Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-349' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=349'>Old School 49</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>427 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2000 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-567' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=567'>Old School 267</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>428 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Royal Titans</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-621' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=621'>Old School 321</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>432 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-500' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=500'>Old School 200</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>445 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-514' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=514'>Old School 214</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>451 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Nightmare of Ashihama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-341' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=341'>Old School 41</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>453 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tempoross</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-373' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=373'>Old School 73</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>455 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-508' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=508'>Old School 208</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>457 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Brimhaven Agility</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-334' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=334'>Old School 34</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>465 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Castle Wars 1</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-407' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=407'>Old School 107</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>480 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-518' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=518'>Old School 218</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>482 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-517' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=517'>Old School 217</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>483 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Varlamore PvM</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-318' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=318'>Old School 18</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>490 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Bounty Hunter World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-524' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=524'>Old School 224</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>513 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-515' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=515'>Old School 215</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>517 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-511' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=511'>Old School 211</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>528 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-516' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=516'>Old School 216</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>530 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-620' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=620'>Old School 320</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>531 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-559' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=559'>Old School 259</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>549 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>LMS Competitive</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-509' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=509'>Old School 209</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>553 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-521' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=521'>Old School 221</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>553 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-513' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=513'>Old School 213</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>554 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Zeah Runecrafting</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-358' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=358'>Old School 58</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>556 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-325' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=325'>Old School 25</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>563 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Yama</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-510' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=510'>Old School 210</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>600 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-520' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=520'>Old School 220</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>603 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-350' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=350'>Old School 50</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>611 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Soul Wars</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-310' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=310'>Old School 10</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>617 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Barbarian Assault</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-333' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=333'>Old School 33</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>661 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tombs of Amascut</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-525' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=525'>Old School 225</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>692 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-317' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=317'>Old School 17</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>703 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-342' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=342'>Old School 42</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>829 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Role-playing</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-309' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=309'>Old School 9</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>872 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wintertodt</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-302' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=302'>Old School 2</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>1964 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--GB'>United Kingdom</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Trade - Members</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-568' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=568'>Old School 268</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>0 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Speedrunning World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-570' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=570'>Old School 270</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>4 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP Arena (AUS)</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--pvp server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-392' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=392'>Old School 92</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>46 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>PvP World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-533' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=533'>Old School 233</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>90 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>High Risk World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-569' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=569'>Old School 269</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>91 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Bounty Hunter World</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-595' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=595'>Old School 295</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>93 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2350 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-526' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=526'>Old School 226</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>110 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2200 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-529' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=529'>Old School 229</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>150 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1250 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-391' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=391'>Old School 91</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>151 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1750 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-527' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=527'>Old School 227</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>152 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>2000 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-528' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=528'>Old School 228</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>158 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>1500 skill total</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-535' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=535'>Old School 235</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>161 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Soul Wars</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-531' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=531'>Old School 231</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>164 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Tombs of Amascut</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-536' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=536'>Old School 236</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>169 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-532' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=532'>Old School 232</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>172 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Group PvM</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-534' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=534'>Old School 234</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>173 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Guardians of the Rift</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-591' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=591'>Old School 291</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>174 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-590' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=590'>Old School 290</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>176 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-412' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=412'>Old School 112</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>186 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-426' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=426'>Old School 126</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>207 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>House Party, Gilded Altar</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-425' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=425'>Old School 125</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>212 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-424' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=424'>Old School 124</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>222 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-387' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=387'>Old School 87</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>225 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Blast Furnace</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-389' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=389'>Old School 89</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>263 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Wintertodt</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-388' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=388'>Old School 88</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>266 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>Forestry</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-390' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=390'>Old School 90</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>287 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--AU'>Australia</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>LMS Competitive</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-695' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=695'>Old School 395</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>422 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--BR'>Brazil</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-693' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=693'>Old School 393</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>425 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--BR'>Brazil</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-694' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=694'>Old School 394</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>493 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--BR'>Brazil</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-664' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=664'>Old School 364</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>198 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--SG'>Singapore</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-663' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=663'>Old School 363</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>203 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--SG'>Singapore</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-662' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=662'>Old School 362</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>232 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--SG'>Singapore</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-661' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=661'>Old School 361</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>256 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--SG'>Singapore</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-700' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=700'>Old School 400</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>170 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--JP'>Japan</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-699' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=699'>Old School 399</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>206 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--JP'>Japan</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                                <tr class='server-list__row server-list__row--members'>
+                                    <td class='server-list__row-cell'>
+                                            <a id='slu-world-668' class='server-list__world-link' href='https://oldschool.runescape.com/game?world=668'>Old School 368</a>
+                                    </td>
+                                    <td class='server-list__row-cell'>261 players</td>
+                                    <td class='server-list__row-cell server-list__row-cell--country server-list__row-cell--ZA'>South Africa</td>
+                                    <td class='server-list__row-cell server-list__row-cell--type'>Members</td>
+                                    <td class='server-list__row-cell'>-</td>
+                                </tr>
+                    </tbody>
+                </table>
+            </section>
+		</main>
+    </div>
+	<footer class='footer'>
+		<a id='footer-jagex-logo' class='footer__jagex' href='https://www.jagex.com/en-GB/' target='_blank'><img class='footer__jagex-img' src='https://www.runescape.com/img/responsive/common/logos/jagex-gold.svg?1' title="Jagex" alt="Jagex" /></a>
+		<p>This website and its contents are copyright &copy; 1999 - 2026 Jagex Games Ltd, 220 Science Park, Cambridge, CB4 0WA, United Kingdom.</p>
+        <p>Use of this website is subject to our <a id='footer-terms' href='https://legal.jagex.com/docs/terms' target='_blank'>Terms &amp; Conditions</a> and <a id='footer-privacy' href='https://legal.jagex.com/docs/policies' target='_blank'>Privacy Policy</a></p>
+		<p>
+			<a id='footer-rules' target='_blank' href='https://legal.jagex.com/docs/rules'>Rules of Old School RuneScape</a> | <a id='footer-cookies' target='_blank' href='https://play.runescape.com/cookies'>Cookie Policy</a> |
+			<a id='footer-manage-cookies' href=''>Manage Cookies</a> | <a id='footer-rights' target='_blank' href='https://legal.jagex.com/docs/policies/privacy/exercising-your-rights' title="Jagex does not sell personal information as the term 'sell' is commonly understood. We do allow service providers to use your personal information for advertising, marketing, and analytics. Please click this link for more information on how to opt out in our Privacy Policy.">Do Not Sell Or Share My Personal Information</a>
+		</p>
+        <a id='footer-rss' class='footer__rss' href='https://secure.runescape.com/m=news/latest_news.rss?oldschool=true' target='_blank'>RSS Feed</a>
+        <div class='footer__pegi m-pegi'>
+            <div class='m-pegi__icons'>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI 16" src='https://www.runescape.com/img/responsive/common/icons/pegi-16.svg' class='m-pegi__age' width='53.313' height='65' />
+                </a>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI icon to represent drug use" title="The game refers to or depicts the use of illegal drugs, alcohol or tobacco." src='https://www.runescape.com/img/responsive/common/icons/pegi-drugs.svg' class='m-pegi__descriptor' width='55' height='55' />
+                </a>
+                <a class='m-pegi__link' href='https://pegi.info/search-pegi?q=runescape&amp;op=Search&amp;age%5B%5D=&amp;descriptor%5B%5D=&amp;publisher=Jagex+Ltd&amp;platform%5B%5D=&amp;release_year%5B%5D=&amp;page=1&amp;form_build_id=form-5Nc7D2ScBDuiMzP9F2ffxljtiSLFY38thQpDSDwRrq0&amp;form_id=pegi_search_form' rel='noopener' target='_blank'>
+                    <img alt="PEGI icon to represent in-game purchases" title="The game offers players the option to purchase digital goods or services with real-world currency." src='https://www.runescape.com/img/responsive/common/icons/pegi-ingame-purchases.svg' class='m-pegi__descriptor' width='55' height='55' />
+                </a>
+            </div>
+            <p class='m-pegi__strap'>In-game Purchases (Includes Random Items)</p>
+        </div>
+		<script>
+			const manageCookieLink = document.querySelector("#footer-manage-cookies");
+			manageCookieLink.addEventListener("click", function onclick(event) {
+				event.preventDefault();
+				window.athena("consent", "triggerBanner");
+			});
+		</script>
+	</footer>
+
+	<script>
+		pageLocation = 'https://www.runescape.com/slu';
+		document.domain = 'runescape.com';
+		var baseURL = 'https://www.runescape.com', homeRedirect = 'https://oldschool.runescape.com/', JXGLOBAL = {};
+		JXGLOBAL.client = [{
+			'platform': 'Windows_x86',
+			'filename': 'oldschool.msi',
+			'version': '1.4.3',
+			'size': '23'
+		},{
+			'platform': 'OSX_x86',
+			'filename': 'runescape.dmg',
+			'version': '1.4.3',
+			'size': '2.5'
+		}];
+
+        var RESPONSIVE = RESPONSIVE || {};
+        RESPONSIVE.constant = RESPONSIVE.constant || {};
+            RESPONSIVE.constant.user = {
+                language: 0,
+                isLoggedIn: 0
+            };
+    </script>
+		<script src='https://www.runescape.com/js/c/responsive/vendor-168.js'></script>
+	<script src='https://www.runescape.com/js/c/rs3/modernizr_3_0_0_min-169.js'></script>
+    <script src='https://www.runescape.com/js/osrs/plugins-155.js'></script>
+	<script src='https://www.runescape.com/js/osrs/gtm-155.js' data-ot-ignore></script>
+	<script src='https://www.runescape.com/js/jagex_global-101.js'></script>
+    <script src='https://www.runescape.com/js/c/os/functions-155.js' async defer></script>
+		</div>
+		<script>var bStyle = document.getElementById('bConHide'); if (bStyle) bStyle.parentNode.removeChild(bStyle);</script>
+    <script>(function(){function c(){var b=a.contentDocument||(a.contentWindow&&a.contentWindow.document);if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a2602bdad981a3b9',t:'MTc4NTg3Mzg2Nw=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,197 @@
+"""Parser tests for rs_tracker.
+
+The fixture tests pin the parsers against a saved copy of each page (see
+tests/fixtures/README.md). The synthetic tests pin the contract itself — the
+edge cases that are easy to break and hard to notice, because a broken parser
+returns [] and the tracker just logs a warning.
+"""
+import os
+import unittest
+
+from rs_tracker import parse_osrs_count, parse_world_data
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+# Facts about the 2026-08-04 capture. A fixture refresh will move these; that's
+# the point — read the diff before updating them.
+EXPECTED_WORLDS = 317
+EXPECTED_FREE = 55
+EXPECTED_MEMBERS = 262
+EXPECTED_LOCATIONS = {
+    'United States': 139,
+    'United Kingdom': 71,
+    'Germany': 63,
+    'Australia': 30,
+    'Singapore': 5,
+    'Brazil': 4,
+    'Japan': 3,
+    'South Africa': 2,
+}
+EXPECTED_TOTAL_COUNT = 131884
+
+
+def fixture(name):
+    with open(os.path.join(FIXTURES, name), 'rb') as f:
+        return f.read()
+
+
+class SluFixtureTest(unittest.TestCase):
+    """parse_world_data against the saved /slu page."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.worlds = parse_world_data(fixture('slu.html'))
+
+    def test_row_count(self):
+        self.assertEqual(len(self.worlds), EXPECTED_WORLDS)
+
+    def test_every_world_is_complete(self):
+        for w in self.worlds:
+            self.assertEqual(
+                set(w), {'world_number', 'player_count', 'location', 'is_f2p', 'activity'})
+            self.assertIsInstance(w['world_number'], int)
+            self.assertIsInstance(w['player_count'], int)
+            self.assertIsInstance(w['is_f2p'], bool)
+            # Activity is legitimately '-' for most worlds, but location never blanks.
+            self.assertTrue(w['location'], f"world {w['world_number']} has no location")
+
+    def test_world_numbers_are_unique(self):
+        numbers = [w['world_number'] for w in self.worlds]
+        self.assertEqual(len(numbers), len(set(numbers)))
+
+    def test_counts_are_in_range(self):
+        for w in self.worlds:
+            self.assertGreaterEqual(w['player_count'], 0)
+            self.assertLessEqual(w['player_count'], 2000)
+
+    def test_type_split(self):
+        free = sum(1 for w in self.worlds if w['is_f2p'])
+        self.assertEqual(free, EXPECTED_FREE)
+        self.assertEqual(len(self.worlds) - free, EXPECTED_MEMBERS)
+
+    def test_locations(self):
+        counts = {}
+        for w in self.worlds:
+            counts[w['location']] = counts.get(w['location'], 0) + 1
+        self.assertEqual(counts, EXPECTED_LOCATIONS)
+
+    def test_known_rows(self):
+        by_number = {w['world_number']: w for w in self.worlds}
+
+        self.assertEqual(by_number[93], {
+            'world_number': 93, 'player_count': 69, 'location': 'United States',
+            'is_f2p': True, 'activity': '750 skill total'})
+
+        # PvP rows carry an extra class on the <tr>; the selector must still match.
+        self.assertEqual(by_number[277], {
+            'world_number': 277, 'player_count': 90, 'location': 'United States',
+            'is_f2p': True, 'activity': 'PvP World - Free'})
+
+        # World 296 has an empty player cell in this capture -> the full-world fallback.
+        self.assertEqual(by_number[296]['player_count'], 2000)
+
+    def test_activity_dash_is_preserved(self):
+        # '-' is the no-activity bucket and must reach the DB as-is; the data dump
+        # depends on it not being normalised away.
+        self.assertIn('-', {w['activity'] for w in self.worlds})
+
+
+class IndexFixtureTest(unittest.TestCase):
+    """parse_osrs_count against the saved front page."""
+
+    def test_total_count(self):
+        self.assertEqual(
+            parse_osrs_count(fixture('index.html').decode('utf-8')), EXPECTED_TOTAL_COUNT)
+
+
+class WorldParserContractTest(unittest.TestCase):
+    """Edge cases, on synthetic markup so they survive a fixture refresh."""
+
+    def row(self, world='Old School 42', players='48 players',
+            location='United Kingdom', type_='Members', activity='-'):
+        return f"""
+        <tr class='server-list__row'>
+          <td><a class='server-list__world-link' href='#'>{world}</a></td>
+          <td>{players}</td>
+          <td>{location}</td>
+          <td>{type_}</td>
+          <td>{activity}</td>
+        </tr>"""
+
+    def parse_one(self, **kw):
+        worlds = parse_world_data(f"<table>{self.row(**kw)}</table>")
+        self.assertEqual(len(worlds), 1)
+        return worlds[0]
+
+    def test_full_world_has_no_number(self):
+        # The server list omits the count when a world is full.
+        self.assertEqual(self.parse_one(players='')['player_count'], 2000)
+
+    def test_empty_world_reports_zero(self):
+        self.assertEqual(self.parse_one(players='0 players')['player_count'], 0)
+
+    def test_thousands_separator(self):
+        self.assertEqual(self.parse_one(players='1,337 players')['player_count'], 1337)
+
+    def test_free_detection_is_case_insensitive(self):
+        self.assertTrue(self.parse_one(type_='FREE')['is_f2p'])
+        self.assertFalse(self.parse_one(type_='Members')['is_f2p'])
+
+    def test_rows_without_a_world_link_are_skipped(self):
+        html = "<table><tr class='server-list__row'><td>x</td><td>1</td>" \
+               "<td>a</td><td>b</td><td>c</td></tr></table>"
+        self.assertEqual(parse_world_data(html), [])
+
+    def test_short_rows_are_skipped(self):
+        html = "<table><tr class='server-list__row'><td>x</td><td>1</td></tr></table>"
+        self.assertEqual(parse_world_data(html), [])
+
+    def test_unrelated_tables_are_ignored(self):
+        html = f"<table><tr><td>not a world</td></tr>{self.row()}</table>"
+        self.assertEqual(len(parse_world_data(html)), 1)
+
+    def test_empty_page(self):
+        self.assertEqual(parse_world_data(''), [])
+
+
+class CountParserContractTest(unittest.TestCase):
+
+    def test_both_phrasings(self):
+        self.assertEqual(parse_osrs_count('<p>101,655 people playing</p>'), 101655)
+        self.assertEqual(parse_osrs_count('<p>101,655 players online</p>'), 101655)
+
+    def test_case_and_spacing(self):
+        self.assertEqual(parse_osrs_count('99 PEOPLE PLAYING'), 99)
+        self.assertEqual(parse_osrs_count('99people playing'), 99)
+
+    def test_missing_count(self):
+        self.assertIsNone(parse_osrs_count('<html>maintenance</html>'))
+        self.assertIsNone(parse_osrs_count(''))
+
+
+@unittest.skipUnless(os.environ.get('RUN_LIVE_SCRAPE_TESTS'),
+                     'set RUN_LIVE_SCRAPE_TESTS=1 to hit the real site')
+class LiveScrapeTest(unittest.TestCase):
+    """Opt-in canary: does the parser still work against the pages as they are now?
+
+    The fixtures can't tell you Jagex changed their markup — only this can. Kept
+    out of the default run so tests stay offline and deterministic.
+    """
+
+    def test_world_list_still_parses(self):
+        from rs_tracker import get_world_data
+        worlds = get_world_data()
+        self.assertGreater(len(worlds), 150, 'server list parsed to implausibly few worlds')
+        self.assertTrue(any(w['is_f2p'] for w in worlds))
+        self.assertTrue(any(not w['is_f2p'] for w in worlds))
+        self.assertTrue(any(w['player_count'] > 0 for w in worlds))
+
+    def test_total_count_still_parses(self):
+        from rs_tracker import get_osrs_count
+        count = get_osrs_count()
+        self.assertIsNotNone(count, 'front page count no longer matches the regex')
+        self.assertGreater(count, 1000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
CI had no tests, and the scrapers were the obvious gap: if Jagex changes the `/slu` markup, `get_world_data()` returns `[]` and the tracker just logs a warning. Nothing else notices.

## What's here

- **`parse_world_data()` / `parse_osrs_count()` split out of the fetching functions** in `rs_tracker.py` so they can run against a saved page. No behaviour change — `get_world_data()`/`get_osrs_count()` still fetch and now delegate.
- **Fixtures are verbatim captures** of `/slu` and the front page rather than trimmed samples, so refreshing is one `curl` and the assertions cover the whole 317-world list.
- **Synthetic tests alongside them** for the edge cases that shouldn't move when a fixture is refreshed: full worlds (no number in the cell), empty worlds, thousands separators, malformed rows.
- **`LiveScrapeTest`** hits the real pages, because a frozen fixture can only catch *us* breaking the parser. It runs as its own CI job — red there next to a green `build` means the site changed, not the commit. Gated behind `RUN_LIVE_SCRAPE_TESTS` locally so the default run stays offline and deterministic.

22 tests, stdlib `unittest`, no new dependency.

## Verification

Mutation-tested the suite rather than trusting green: six deliberate parser breaks — class selector, cell-count guard, full-world fallback, f2p test, column index, world-number regex — all caught.

## Not in scope

Left the `--exit-zero` flake8 pass alone. Project code has 84 violations including five `C901` complexity failures (`get_history_grouped` at 19, `make_dump.main` at 14), so making it blocking is a cleanup pass rather than a flag flip.

## Note on branch protection

If `live-scrape` is ever marked a required check, a Jagex outage would block merges. It's meant to be informational.
