### PR TITLE
Make flake8 blocking and cut the complexity it was flagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,8 @@ jobs:
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      # Blocking. Settings live in setup.cfg so a local `flake8` matches this.
+      run: flake8 . --count --show-source --statistics
     - name: Test
       run: python -m unittest discover -s tests -t . -v
 

--- a/config.py
+++ b/config.py
@@ -12,7 +12,8 @@ OSRS_MAIN_URL = "https://oldschool.runescape.com/"
 OSRS_SLU_URL = "https://oldschool.runescape.com/slu"
 
 # Scraper Settings
-SCRAPE_INTERVAL = 300 # 5 minutes
+SCRAPE_INTERVAL = 300  # 5 minutes
 WORLD_SCRAPE_INTERVAL = 1800  # 30 minutes
 REQUEST_TIMEOUT = 15
-USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+USER_AGENT = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+              '(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36')

--- a/database.py
+++ b/database.py
@@ -4,6 +4,7 @@ from config import DB_PATH
 
 logger = logging.getLogger(__name__)
 
+
 def get_db_connection():
     """Establishes a connection to the SQLite database."""
     try:
@@ -13,6 +14,7 @@ def get_db_connection():
     except sqlite3.Error as e:
         logger.error(f"Database connection error: {e}")
         raise
+
 
 def init_db():
     """

--- a/osrs_api.py
+++ b/osrs_api.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, request, render_template
 from flask_cors import CORS
 import os
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
 
@@ -22,17 +23,21 @@ if hasattr(app, 'json'):
 else:
     app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
+
 @app.route('/')
 def home():
     return render_template('index.html')
+
 
 @app.route('/robots.txt')
 def robots():
     return app.send_static_file('robots.txt')
 
+
 @app.route('/sitemap.xml')
 def sitemap():
     return app.send_static_file('sitemap.xml')
+
 
 @app.route('/api/latest')
 def get_latest():
@@ -41,32 +46,33 @@ def get_latest():
     try:
         # Get the last row added to players (global count)
         row = conn.execute('SELECT * FROM players ORDER BY id DESC LIMIT 1').fetchone()
-        
+
         f2p_count = 0
         members_count = 0
-        
+
         if row:
             try:
-                latest_scrape = conn.execute('SELECT id, timestamp FROM scrape_events ORDER BY timestamp DESC LIMIT 1').fetchone()
+                latest_scrape = conn.execute(
+                    'SELECT id, timestamp FROM scrape_events ORDER BY timestamp DESC LIMIT 1').fetchone()
                 breakdown_ts = None
                 if latest_scrape:
                     scrape_id = latest_scrape['id']
                     breakdown_ts = latest_scrape['timestamp']
-                    
+
                     # Calculate F2P count
                     f2p_res = conn.execute('''
-                        SELECT SUM(wd.player_count) as count 
-                        FROM world_data wd 
-                        JOIN world_details det ON wd.detail_id = det.id 
+                        SELECT SUM(wd.player_count) as count
+                        FROM world_data wd
+                        JOIN world_details det ON wd.detail_id = det.id
                         WHERE wd.scrape_id = ? AND det.is_f2p = 1
                     ''', (scrape_id,)).fetchone()
                     f2p_count = f2p_res['count'] if f2p_res and f2p_res['count'] else 0
-                    
+
                     # Calculate Members count
                     mem_res = conn.execute('''
-                        SELECT SUM(wd.player_count) as count 
-                        FROM world_data wd 
-                        JOIN world_details det ON wd.detail_id = det.id 
+                        SELECT SUM(wd.player_count) as count
+                        FROM world_data wd
+                        JOIN world_details det ON wd.detail_id = det.id
                         WHERE wd.scrape_id = ? AND det.is_f2p = 0
                     ''', (scrape_id,)).fetchone()
                     members_count = mem_res['count'] if mem_res and mem_res['count'] else 0
@@ -86,6 +92,7 @@ def get_latest():
     finally:
         conn.close()
 
+
 @app.route('/api/metadata')
 def get_metadata():
     """Returns lists of worlds, locations, and activities for filtering."""
@@ -93,10 +100,10 @@ def get_metadata():
     try:
         # Get Locations
         locations = conn.execute('SELECT id, name FROM locations ORDER BY name').fetchall()
-        
+
         # Get Activities
         activities = conn.execute('SELECT id, description FROM activities ORDER BY description').fetchall()
-        
+
         # Loose index scan over idx_world_number: one seek per world instead of
         # walking ~4M rows. Not SELECT DISTINCT, which is ~215ms here vs ~2ms.
         worlds = conn.execute('''
@@ -112,7 +119,7 @@ def get_metadata():
             WHERE world_number IS NOT NULL
             ORDER BY world_number
         ''').fetchall()
-        
+
         return jsonify({
             "locations": [{"id": row['id'], "name": row['name']} for row in locations],
             "activities": [{"id": row['id'], "description": row['description']} for row in activities],
@@ -120,6 +127,7 @@ def get_metadata():
         })
     finally:
         conn.close()
+
 
 ISO_Z = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -136,6 +144,7 @@ def parse_iso(ts):
             return datetime.strptime(ts2, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc)
         except Exception:
             return None
+
 
 def iso_z(dt):
     """Format for comparison against stored timestamps, which are all `...Z`.
@@ -224,6 +233,47 @@ def _imported_history(conn, start_dt, end_dt, unit, agg):
             for r in conn.execute(query, params)]
 
 
+def _rows_to_series(rows, descending=False):
+    """Query rows to the [{timestamp, count}] the frontend expects, always ascending."""
+    results = [{"timestamp": r['timestamp'], "count": r['count']} for r in rows]
+    if descending:
+        results.reverse()
+    return results
+
+
+def _scrape_id_bounds(conn, start_dt, end_dt):
+    """A time range as (min_id, max_id) over scrape_events.
+
+    scrape_id is the world_data PK prefix, so filtering on the resolved ids is a
+    range scan; filtering on se.timestamp makes SQLite walk every row and only
+    then discard it. None when the range holds no scrapes at all; max_id is None
+    when the range is open-ended.
+    """
+    lo = conn.execute('SELECT MIN(id) FROM scrape_events WHERE timestamp >= ?',
+                      (iso_z(start_dt),)).fetchone()[0]
+    if lo is None:
+        return None
+    hi = None
+    if end_dt:
+        hi = conn.execute('SELECT MAX(id) FROM scrape_events WHERE timestamp <= ?',
+                          (iso_z(end_dt),)).fetchone()[0]
+        if hi is None:
+            return None
+    return lo, hi
+
+
+def _world_detail_clauses(location_id, is_f2p):
+    """(clauses, params) for the world_details filters shared by both endpoints."""
+    clauses, params = [], []
+    if location_id is not None:
+        clauses.append("det.location_id = ?")
+        params.append(location_id)
+    if is_f2p is not None:
+        clauses.append("det.is_f2p = ?")
+        params.append(is_f2p)
+    return clauses, params
+
+
 # group_by value -> (key expression, whether counts must be summed across worlds
 # within a scrape before aggregating across time)
 GROUPINGS = {
@@ -239,6 +289,260 @@ MAX_GROUPED_POINTS = 600000
 
 BUCKET_SECONDS = {'hour': 3600, 'day': 86400, 'week': 604800, 'month': 2592000}
 
+TOO_MANY_POINTS_MSG = ("Too many points for one comparison. "
+                       "Use a coarser granularity or a shorter time range.")
+
+MINUTE_SPAN_MSG = ("Minute-level queries cannot span more than 30 days. "
+                   "Please use a larger unit (hour/day) or a shorter time range.")
+
+
+@dataclass
+class HistoryQuery:
+    """Parsed /api/history query params. New filters get a field here and a
+    clause in _world_history; nothing in between needs to know about them."""
+    limit: int = None
+    start_dt: datetime = None
+    end_dt: datetime = None
+    unit: str = None
+    step: int = None
+    agg: str = 'max'
+    world_id: int = None
+    location_id: int = None
+    is_f2p: int = None
+
+    @classmethod
+    def from_request(cls):
+        return cls(
+            limit=request.args.get('limit', default=None, type=int),
+            start_dt=parse_iso(request.args.get('start')),
+            end_dt=parse_iso(request.args.get('end')),
+            unit=request.args.get('unit', default=None, type=str),
+            step=request.args.get('step', default=None, type=int),
+            agg=request.args.get('agg', default='max', type=str),
+            world_id=request.args.get('world_id', default=None, type=int),
+            location_id=request.args.get('location_id', default=None, type=int),
+            is_f2p=request.args.get('is_f2p', default=None, type=int),
+        )
+
+    @property
+    def agg_func(self):
+        return "ROUND(AVG(count))" if self.agg == 'avg' else "MAX(count)"
+
+    @property
+    def use_world_data(self):
+        """Whether any filter forces the per-world tables instead of `players`."""
+        return (self.world_id is not None or self.location_id is not None
+                or self.is_f2p is not None)
+
+    @property
+    def minute_span_exceeded(self):
+        """Minute granularity over more than 30 days. A missing start means the
+        query defaults to a recent window later, so there is nothing to check."""
+        if self.unit != 'minute' or not self.step or self.start_dt is None:
+            return False
+        end = self.end_dt or datetime.now(timezone.utc)
+        return (end - self.start_dt) > timedelta(days=30)
+
+
+def _world_history(conn, q):
+    """One series from world_data: a single world's count, or the sum over the
+    worlds matching the filters at each scrape."""
+    from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
+    if q.location_id is not None or q.is_f2p is not None:
+        from_clause += " JOIN world_details det ON wd.detail_id = det.id"
+
+    where_clauses, params = [], []
+    if q.world_id is not None:
+        select_clause = "SELECT se.timestamp as timestamp, wd.player_count as count"
+        group_by = ""
+        where_clauses.append("wd.world_number = ?")
+        params.append(q.world_id)
+    else:
+        select_clause = "SELECT se.timestamp as timestamp, SUM(wd.player_count) as count"
+        group_by = "GROUP BY se.id"
+
+    detail_clauses, detail_params = _world_detail_clauses(q.location_id, q.is_f2p)
+    where_clauses += detail_clauses
+    params += detail_params
+
+    # `limit` means "most recent N", which only applies when no range was given.
+    tail_request = q.start_dt is None and q.end_dt is None
+
+    # An unbounded range here has no scrape_id bounds to restrict to, so it
+    # scans all of world_data. Default to 7d, as /api/history/grouped does.
+    start_dt, end_dt = q.start_dt, q.end_dt
+    if start_dt is None:
+        end_dt = end_dt or datetime.now(timezone.utc)
+        start_dt = end_dt - timedelta(days=7)
+
+    bounds = _scrape_id_bounds(conn, start_dt, end_dt)
+    if bounds is None:
+        return []
+    lo, hi = bounds
+    where_clauses.append("wd.scrape_id >= ?")
+    params.append(lo)
+    if hi is not None:
+        where_clauses.append("wd.scrape_id <= ?")
+        params.append(hi)
+
+    where_str = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+    # One (timestamp, count) row per scrape event.
+    inner = f"{select_clause} {from_clause} {where_str} {group_by}"
+
+    buckets = _bucket_exprs(q.unit, q.step, 'timestamp')
+    descending = False
+    if buckets:
+        # Two levels on purpose: the inner SUM adds up worlds at one instant,
+        # the outer agg reduces across instants in the bucket. Collapsing them
+        # would sum across time.
+        bucket_select, bucket_group = buckets
+        query = (f"SELECT {bucket_select} as timestamp, {q.agg_func} as count "
+                 f"FROM ({inner}) GROUP BY {bucket_group} ORDER BY timestamp ASC")
+    else:
+        descending = bool(tail_request and q.limit)
+        order_by = "ORDER BY se.timestamp DESC" if descending else "ORDER BY se.timestamp ASC"
+        limit_clause = f"LIMIT {q.limit}" if descending else ""
+        query = f"{inner} {order_by} {limit_clause}"
+
+    return _rows_to_series(conn.execute(query, params).fetchall(), descending)
+
+
+def _global_history(conn, q):
+    """The global series from `players`, with the imported era spliced on."""
+    buckets = _bucket_exprs(q.unit, q.step, 'timestamp')
+    if buckets:
+        bucket_select, bucket_group = buckets
+        select_clause = f"SELECT {bucket_select} as timestamp, {q.agg_func} as count"
+        group_by = f"GROUP BY {bucket_group}"
+    else:
+        select_clause = "SELECT timestamp, count"
+        group_by = ""
+
+    where_clauses, params = [], []
+    if q.start_dt:
+        where_clauses.append("timestamp >= ?")
+        params.append(iso_z(q.start_dt))
+    if q.end_dt:
+        where_clauses.append("timestamp <= ?")
+        params.append(iso_z(q.end_dt))
+
+    # Split the two eras at the end of imported coverage. Keeping this on the
+    # native query as well as the imported one means the old weekly rows can
+    # sit in `players` without being double-counted, which is what lets the
+    # data load and the code deploy happen as separate steps.
+    import_end = _import_end(conn)
+    if import_end:
+        where_clauses.append("timestamp >= ?")
+        params.append(import_end)
+
+    # No range and no bucketing is the "last N samples" call: take the tail and
+    # flip it back to ascending.
+    descending = not q.start_dt and not q.end_dt and not buckets
+    order_by = "ORDER BY timestamp DESC" if descending else "ORDER BY timestamp ASC"
+    limit_clause = f"LIMIT {q.limit or 288}" if descending else ""
+
+    where_str = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+    query = f"{select_clause} FROM players {where_str} {group_by} {order_by} {limit_clause}"
+
+    results = _rows_to_series(conn.execute(query, params).fetchall(), descending)
+
+    # Prepend the imported era when the request actually reaches into it.
+    # Skipped for the bare "last N samples" call, which is asking about now.
+    if import_end and (buckets or q.start_dt or q.end_dt):
+        if not q.start_dt or iso_z(q.start_dt) < import_end:
+            results = _imported_history(conn, q.start_dt, q.end_dt, q.unit, q.agg) + results
+
+    return results
+
+
+def _grouped_error(q, group_by, buckets):
+    """The 400 response for an unusable /api/history/grouped request, else None."""
+    if group_by not in GROUPINGS:
+        return jsonify({"error": f"group_by must be one of: {', '.join(GROUPINGS)}"}), 400
+    if not buckets:
+        return jsonify({"error": "unit is required: minute, hour, day, week or month."}), 400
+    if q.start_dt > q.end_dt:
+        return jsonify({"error": "start must be before end."}), 400
+    if q.unit == 'minute' and (q.end_dt - q.start_dt) > timedelta(days=30):
+        return jsonify({"error": MINUTE_SPAN_MSG}), 400
+    return None
+
+
+def _grouped_over_cap(conn, q, lo, hi):
+    """Whether the response would exceed the point cap, estimated without running
+    the query. Only worlds can realistically blow it (hundreds of series);
+    grouping by location or f2p is a handful either way."""
+    bucket_secs = BUCKET_SECONDS.get(q.unit) or (q.step if q.step else 5) * 60
+    scrapes = hi - lo + 1
+    est_buckets = min((q.end_dt - q.start_dt).total_seconds() // bucket_secs + 1, scrapes)
+    est_series = conn.execute(
+        'SELECT COUNT(*) FROM world_data WHERE scrape_id = ?', (hi,)).fetchone()[0]
+    return est_buckets * est_series > MAX_GROUPED_POINTS
+
+
+def _grouped_query(q, group_by, buckets, lo, hi):
+    """(sql, params) for one row per (bucket, series key), ordered by bucket."""
+    key_expr, sum_within_scrape = GROUPINGS[group_by]
+
+    from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
+    if sum_within_scrape or q.location_id is not None or q.is_f2p is not None:
+        from_clause += " JOIN world_details det ON wd.detail_id = det.id"
+
+    where_clauses = ["wd.scrape_id >= ?", "wd.scrape_id <= ?"]
+    params = [lo, hi]
+    if q.world_id is not None:
+        where_clauses.append("wd.world_number = ?")
+        params.append(q.world_id)
+    detail_clauses, detail_params = _world_detail_clauses(q.location_id, q.is_f2p)
+    where_clauses += detail_clauses
+    params += detail_params
+    where_str = "WHERE " + " AND ".join(where_clauses)
+
+    if sum_within_scrape:
+        # Two levels, as in get_history: inner adds up worlds at one instant,
+        # outer reduces across the instants in a bucket.
+        inner = (f"SELECT se.timestamp AS timestamp, {key_expr} AS k, SUM(wd.player_count) AS count "
+                 f"{from_clause} {where_str} GROUP BY se.id, k")
+    else:
+        # world_data PK is (scrape_id, world_number), so a row already is one
+        # world at one instant.
+        inner = (f"SELECT se.timestamp AS timestamp, {key_expr} AS k, wd.player_count AS count "
+                 f"{from_clause} {where_str}")
+
+    bucket_select, bucket_group = buckets
+    query = (f"SELECT {bucket_select} AS ts, k, {q.agg_func} AS count FROM ({inner}) "
+             f"GROUP BY {bucket_group}, k ORDER BY ts ASC LIMIT {MAX_GROUPED_POINTS + 1}")
+    return query, params
+
+
+def _align_series(rows):
+    """Bucket-ordered rows into timestamps plus one count array per key.
+
+    Rows arrive ordered by bucket, so timestamps builds up in order and each
+    series is padded to the current bucket index as it goes.
+    """
+    timestamps = []
+    ts_index = {}
+    series = {}
+    for row in rows:
+        idx = ts_index.get(row['ts'])
+        if idx is None:
+            idx = len(timestamps)
+            ts_index[row['ts']] = idx
+            timestamps.append(row['ts'])
+        counts = series.setdefault(row['k'], [])
+        counts.extend([None] * (idx - len(counts)))
+        counts.append(row['count'])
+
+    for counts in series.values():
+        counts.extend([None] * (len(timestamps) - len(counts)))
+
+    return {
+        "timestamps": timestamps,
+        "series": [{"key": k, "counts": series[k]}
+                   for k in sorted(series, key=lambda v: (v is None, v))]
+    }
+
 
 @app.route('/api/history/grouped')
 def get_history_grouped():
@@ -252,115 +556,36 @@ def get_history_grouped():
     Returns {"timestamps": [...], "series": [{"key": k, "counts": [n|null, ...]}]}
     where each counts array is aligned to timestamps by index.
     """
+    q = HistoryQuery.from_request()
     group_by = request.args.get('group_by', default='world', type=str)
-    if group_by not in GROUPINGS:
-        return jsonify({"error": f"group_by must be one of: {', '.join(GROUPINGS)}"}), 400
-
-    unit = request.args.get('unit', default=None, type=str)
-    step = request.args.get('step', default=None, type=int)
-    agg = request.args.get('agg', default='max', type=str)
-    world_id = request.args.get('world_id', default=None, type=int)
-    location_id = request.args.get('location_id', default=None, type=int)
-    is_f2p = request.args.get('is_f2p', default=None, type=int)
-
-    buckets = _bucket_exprs(unit, step, 'timestamp')
-    if not buckets:
-        return jsonify({"error": "unit is required: minute, hour, day, week or month."}), 400
+    buckets = _bucket_exprs(q.unit, q.step, 'timestamp')
 
     # Unlike /api/history this never serves an unbounded range: many series over
     # all of world_data is a guaranteed full scan.
-    end_dt = parse_iso(request.args.get('end')) or datetime.now(timezone.utc)
-    start_dt = parse_iso(request.args.get('start')) or (end_dt - timedelta(days=7))
-    if start_dt > end_dt:
-        return jsonify({"error": "start must be before end."}), 400
-    if unit == 'minute' and (end_dt - start_dt) > timedelta(days=30):
-        return jsonify({"error": "Minute-level queries cannot span more than 30 days. Please use a larger unit (hour/day) or a shorter time range."}), 400
+    q.end_dt = q.end_dt or datetime.now(timezone.utc)
+    q.start_dt = q.start_dt or (q.end_dt - timedelta(days=7))
 
-    agg_func = "ROUND(AVG(count))" if agg == 'avg' else "MAX(count)"
-    key_expr, sum_within_scrape = GROUPINGS[group_by]
+    error = _grouped_error(q, group_by, buckets)
+    if error:
+        return error
 
     conn = get_db_connection()
     try:
-        # Resolve the range to scrape_id bounds so this is a range scan over the
-        # world_data PK, not a filter on se.timestamp. Same reasoning as get_history.
-        lo = conn.execute('SELECT MIN(id) FROM scrape_events WHERE timestamp >= ?',
-                          (iso_z(start_dt),)).fetchone()[0]
-        hi = conn.execute('SELECT MAX(id) FROM scrape_events WHERE timestamp <= ?',
-                          (iso_z(end_dt),)).fetchone()[0]
-        if lo is None or hi is None:
+        bounds = _scrape_id_bounds(conn, q.start_dt, q.end_dt)
+        if bounds is None:
             return jsonify({"timestamps": [], "series": []})
-
-        from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
-        if sum_within_scrape or location_id is not None or is_f2p is not None:
-            from_clause += " JOIN world_details det ON wd.detail_id = det.id"
-
-        where_clauses = ["wd.scrape_id >= ?", "wd.scrape_id <= ?"]
-        params = [lo, hi]
-        if world_id is not None:
-            where_clauses.append("wd.world_number = ?")
-            params.append(world_id)
-        if location_id is not None:
-            where_clauses.append("det.location_id = ?")
-            params.append(location_id)
-        if is_f2p is not None:
-            where_clauses.append("det.is_f2p = ?")
-            params.append(is_f2p)
-        where_str = "WHERE " + " AND ".join(where_clauses)
+        lo, hi = bounds
 
         # Reject oversized requests before running the query rather than after.
-        # Only worlds can realistically blow the cap (hundreds of series); grouping
-        # by location or f2p is a handful either way.
-        if group_by == 'world':
-            bucket_secs = BUCKET_SECONDS.get(unit) or (step if step else 5) * 60
-            scrapes = hi - lo + 1
-            est_buckets = min((end_dt - start_dt).total_seconds() // bucket_secs + 1, scrapes)
-            est_series = conn.execute(
-                'SELECT COUNT(*) FROM world_data WHERE scrape_id = ?', (hi,)).fetchone()[0]
-            if est_buckets * est_series > MAX_GROUPED_POINTS:
-                return jsonify({"error": "Too many points for one comparison. Use a coarser granularity or a shorter time range."}), 400
+        if group_by == 'world' and _grouped_over_cap(conn, q, lo, hi):
+            return jsonify({"error": TOO_MANY_POINTS_MSG}), 400
 
-        if sum_within_scrape:
-            # Two levels, as in get_history: inner adds up worlds at one instant,
-            # outer reduces across the instants in a bucket.
-            inner = (f"SELECT se.timestamp AS timestamp, {key_expr} AS k, SUM(wd.player_count) AS count "
-                     f"{from_clause} {where_str} GROUP BY se.id, k")
-        else:
-            # world_data PK is (scrape_id, world_number), so a row already is one
-            # world at one instant.
-            inner = (f"SELECT se.timestamp AS timestamp, {key_expr} AS k, wd.player_count AS count "
-                     f"{from_clause} {where_str}")
-
-        bucket_select, bucket_group = buckets
-        query = (f"SELECT {bucket_select} AS ts, k, {agg_func} AS count FROM ({inner}) "
-                 f"GROUP BY {bucket_group}, k ORDER BY ts ASC LIMIT {MAX_GROUPED_POINTS + 1}")
-
+        query, params = _grouped_query(q, group_by, buckets, lo, hi)
         rows = conn.execute(query, params).fetchall()
         if len(rows) > MAX_GROUPED_POINTS:
-            return jsonify({"error": "Too many points for one comparison. Use a coarser granularity or a shorter time range."}), 400
+            return jsonify({"error": TOO_MANY_POINTS_MSG}), 400
 
-        # Rows arrive ordered by bucket, so timestamps builds up in order and each
-        # series is padded to the current bucket index as it goes.
-        timestamps = []
-        ts_index = {}
-        series = {}
-        for row in rows:
-            idx = ts_index.get(row['ts'])
-            if idx is None:
-                idx = len(timestamps)
-                ts_index[row['ts']] = idx
-                timestamps.append(row['ts'])
-            counts = series.setdefault(row['k'], [])
-            counts.extend([None] * (idx - len(counts)))
-            counts.append(row['count'])
-
-        for counts in series.values():
-            counts.extend([None] * (len(timestamps) - len(counts)))
-
-        return jsonify({
-            "timestamps": timestamps,
-            "series": [{"key": k, "counts": series[k]}
-                       for k in sorted(series, key=lambda v: (v is None, v))]
-        })
+        return jsonify(_align_series(rows))
     except Exception as e:
         logger.error(f"Error in get_history_grouped: {e}")
         return jsonify({"error": str(e)}), 500
@@ -379,230 +604,24 @@ def get_history():
         - unit (str): aggregation unit, one of 'minute', 'hour', 'day', 'week', 'month'.
         - step (int): bucket size in minutes.
         - agg (str): 'max' or 'avg'.
-        
-        NEW FILTERS:
         - world_id (int): Filter by specific world number.
         - location_id (int): Filter by location ID.
         - is_f2p (bool/int): Filter by F2P status (1=True, 0=False).
     """
-    # Query params
-    limit = request.args.get('limit', default=None, type=int)
-    start = request.args.get('start', default=None, type=str)
-    end = request.args.get('end', default=None, type=str)
-    unit = request.args.get('unit', default=None, type=str)
-    step = request.args.get('step', default=None, type=int)
-    agg = request.args.get('agg', default='max', type=str)
-    
-    # New Filters
-    world_id = request.args.get('world_id', default=None, type=int)
-    location_id = request.args.get('location_id', default=None, type=int)
-    is_f2p = request.args.get('is_f2p', default=None, type=int) # 0 or 1
-
-    # Determine aggregation SQL function
-    agg_func = "MAX(count)"
-    if agg == 'avg':
-        agg_func = "ROUND(AVG(count))"
-
-    start_dt = parse_iso(start)
-    end_dt = parse_iso(end)
-
-    # Enforce server-side limit: minute-level queries (unit=minute) cannot span more than 30 days
-    if unit == 'minute' and step:
-        # If start/end are provided, validate duration. If missing, treat as last-24h (allowed)
-        if start_dt is None and end_dt is None:
-            pass # Defaults to last 24h later
-        elif start_dt and end_dt:
-            duration = end_dt - start_dt
-            if duration > timedelta(days=30):
-                return jsonify({"error": "Minute-level queries cannot span more than 30 days. Please use a larger unit (hour/day) or a shorter time range."}), 400
-        elif start_dt:
-            # If only start is provided, check against now
-            duration = datetime.now(timezone.utc) - start_dt
-            if duration > timedelta(days=30):
-                return jsonify({"error": "Minute-level queries cannot span more than 30 days."}), 400
+    q = HistoryQuery.from_request()
+    if q.minute_span_exceeded:
+        return jsonify({"error": MINUTE_SPAN_MSG}), 400
 
     conn = get_db_connection()
     try:
-        # --- QUERY CONSTRUCTION ---
-        
-        # Determine if we are querying the main 'players' table or the 'world_data' system
-        use_world_data = (world_id is not None) or (location_id is not None) or (is_f2p is not None)
-        
-        if use_world_data:
-            # We are querying detailed world data
-            # Note: Aggregation (unit/step) logic for world data is complex. 
-            # For now, let's implement raw data return for world data, 
-            # or simple aggregation if requested.
-            
-            # Base Join
-            from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
-            where_clauses = []
-            params = []
-            group_by = ""
-            order_by = "ORDER BY se.timestamp ASC"
-            
-            # If filtering by location or f2p, we need world_details
-            if location_id is not None or is_f2p is not None:
-                from_clause += " JOIN world_details det ON wd.detail_id = det.id"
-                
-            # Select Timestamp
-            select_clause = "SELECT se.timestamp as timestamp"
-            
-            # Select Count
-            if world_id is not None:
-                # Specific world -> just the count
-                select_clause += ", wd.player_count as count"
-                where_clauses.append("wd.world_number = ?")
-                params.append(world_id)
-            else:
-                # Location or F2P -> Sum of counts
-                select_clause += ", SUM(wd.player_count) as count"
-                group_by = "GROUP BY se.id" # Group by scrape event
-                
-            # Apply Location/F2P filters (applies to both specific world and aggregated queries)
-            if location_id is not None:
-                where_clauses.append("det.location_id = ?")
-                params.append(location_id)
-            
-            if is_f2p is not None:
-                where_clauses.append("det.is_f2p = ?")
-                params.append(is_f2p)
-
-            # `limit` means "most recent N", which only applies when no range was given.
-            tail_request = start_dt is None and end_dt is None
-
-            # An unbounded range here has no scrape_id bounds to restrict to, so it
-            # scans all of world_data. Default to 7d, as /api/history/grouped does.
-            if start_dt is None:
-                end_dt = end_dt or datetime.now(timezone.utc)
-                start_dt = end_dt - timedelta(days=7)
-
-            # Resolve the time range to a scrape_id range and filter on that instead
-            # of se.timestamp. scrape_id is the world_data PK prefix, so this is a
-            # range scan; filtering on se.timestamp makes SQLite scan all ~4M rows
-            # and only then discard them (4800ms vs 10ms on a 7 day window).
-            if start_dt:
-                lo = conn.execute('SELECT MIN(id) FROM scrape_events WHERE timestamp >= ?',
-                                  (iso_z(start_dt),)).fetchone()[0]
-                if lo is None:
-                    return jsonify([])
-                where_clauses.append("wd.scrape_id >= ?")
-                params.append(lo)
-            if end_dt:
-                hi = conn.execute('SELECT MAX(id) FROM scrape_events WHERE timestamp <= ?',
-                                  (iso_z(end_dt),)).fetchone()[0]
-                if hi is None:
-                    return jsonify([])
-                where_clauses.append("wd.scrape_id <= ?")
-                params.append(hi)
-                
-            where_str = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
-            # One (timestamp, count) row per scrape event.
-            inner = f"{select_clause} {from_clause} {where_str} {group_by}"
-
-            buckets = _bucket_exprs(unit, step, 'timestamp')
-            if buckets:
-                # Two levels on purpose: the inner SUM adds up worlds at one instant,
-                # the outer agg reduces across instants in the bucket. Collapsing them
-                # would sum across time.
-                bucket_select, bucket_group = buckets
-                query = (f"SELECT {bucket_select} as timestamp, {agg_func} as count "
-                         f"FROM ({inner}) GROUP BY {bucket_group} ORDER BY timestamp ASC")
-            else:
-                limit_clause = ""
-                if tail_request and limit:
-                    limit_clause = f"LIMIT {limit}"
-                    order_by = "ORDER BY se.timestamp DESC"
-                query = f"{inner} {order_by} {limit_clause}"
-
-            rows = conn.execute(query, params).fetchall()
-            
-            results = []
-            for row in rows:
-                results.append({
-                    "timestamp": row['timestamp'],
-                    "count": row['count']
-                })
-                
-            if "DESC" in order_by:
-                results.reverse()
-                
-            return jsonify(results)
-                 
-        else:
-            # Standard Global History (players table)
-            table = "players"
-            col_ts = "timestamp"
-            col_count = "count"
-            
-            select_clause = ""
-            group_by = ""
-            
-            buckets = _bucket_exprs(unit, step, col_ts)
-            if buckets:
-                bucket_select, bucket_group = buckets
-                select_clause = f"SELECT {bucket_select} as timestamp, {agg_func} as count"
-                group_by = f"GROUP BY {bucket_group}"
-            else:
-                # Raw Data
-                select_clause = f"SELECT {col_ts}, {col_count}"
-            
-            from_clause = f"FROM {table}"
-            where_clauses = []
-            params = []
-
-            if start_dt:
-                where_clauses.append(f"{col_ts} >= ?")
-                params.append(iso_z(start_dt))
-            if end_dt:
-                where_clauses.append(f"{col_ts} <= ?")
-                params.append(iso_z(end_dt))
-
-            # Split the two eras at the end of imported coverage. Keeping this on the
-            # native query as well as the imported one means the old weekly rows can
-            # sit in `players` without being double-counted, which is what lets the
-            # data load and the code deploy happen as separate steps.
-            import_end = _import_end(conn)
-            if import_end:
-                where_clauses.append(f"{col_ts} >= ?")
-                params.append(import_end)
-
-            limit_clause = ""
-            order_by = "ORDER BY timestamp ASC"
-
-            if not start_dt and not end_dt and not buckets:
-                lim = limit if limit else 288
-                limit_clause = f"LIMIT {lim}"
-                order_by = "ORDER BY timestamp DESC"
-
-            where_str = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
-            query = f"{select_clause} {from_clause} {where_str} {group_by} {order_by} {limit_clause}"
-            
-            rows = conn.execute(query, params).fetchall()
-
-            results = []
-            for row in rows:
-                results.append({
-                    "timestamp": row['timestamp'],
-                    "count": row['count']
-                })
-
-            if "DESC" in order_by:
-                results.reverse()
-
-            # Prepend the imported era when the request actually reaches into it.
-            # Skipped for the bare "last N samples" call, which is asking about now.
-            if import_end and (buckets or start_dt or end_dt):
-                if not start_dt or iso_z(start_dt) < import_end:
-                    results = _imported_history(conn, start_dt, end_dt, unit, agg) + results
-
-            return jsonify(results)
-
+        builder = _world_history if q.use_world_data else _global_history
+        return jsonify(builder(conn, q))
     except Exception as e:
         logger.error(f"Error in get_history: {e}")
         return jsonify({"error": str(e)}), 500
     finally:
         conn.close()
+
 
 if __name__ == '__main__':
     # Run the server on port 5000

--- a/rs_tracker.py
+++ b/rs_tracker.py
@@ -20,12 +20,14 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
 def parse_osrs_count(html):
     """Pull the total player count out of the front page. None if absent."""
     match = re.search(r"([\d,]+)\s*(?:people playing|players online)", html, re.IGNORECASE)
     if match:
         return int(match.group(1).replace(',', ''))
     return None
+
 
 def get_osrs_count():
     try:
@@ -40,6 +42,7 @@ def get_osrs_count():
         logger.error(f"Error scraping total count: {e}")
 
     return None
+
 
 def parse_world_data(html):
     """Pull one dict per world out of the /slu server list.
@@ -62,7 +65,7 @@ def parse_world_data(html):
         world_link = cells[0].find('a', class_='server-list__world-link')
         if not world_link:
             continue
-        world_text = world_link.get_text(strip=True) # e.g., "Old School 93"
+        world_text = world_link.get_text(strip=True)  # e.g., "Old School 93"
         # Extract number
         world_match = re.search(r"Old School (\d+)", world_text)
         if not world_match:
@@ -70,7 +73,7 @@ def parse_world_data(html):
         world_number = int(world_match.group(1))
 
         # 2. Player Count
-        players_text = cells[1].get_text(strip=True) # e.g., "48 players"
+        players_text = cells[1].get_text(strip=True)  # e.g., "48 players"
         player_match = re.search(r"([\d,]+)", players_text)
 
         if player_match:
@@ -99,6 +102,7 @@ def parse_world_data(html):
 
     return world_rows
 
+
 def get_world_data():
     try:
         headers = {'User-Agent': USER_AGENT}
@@ -111,11 +115,85 @@ def get_world_data():
         logger.error(f"Error scraping world data: {e}")
         return []
 
+
+def _intern(conn, cache, table, column, value):
+    """The row id for `value` in a lookup table, inserting it if it's new.
+
+    `cache` is seeded from the table once per scrape and updated in place, so a
+    scrape does at most one INSERT per genuinely new value.
+    """
+    if value not in cache:
+        cursor = conn.execute(f"INSERT INTO {table} ({column}) VALUES (?)", (value,))
+        cache[value] = cursor.lastrowid
+    return cache[value]
+
+
+def _save_world_data(conn, scrape_id, world_data_list):
+    """One world_data row per world, interning the locations, activities and
+    (location, f2p, activity) combinations they reference."""
+    location_map = {row[0]: row[1] for row in conn.execute("SELECT name, id FROM locations")}
+    activity_map = {row[0]: row[1] for row in conn.execute("SELECT description, id FROM activities")}
+    details_map = {
+        (row[0], bool(row[1]), row[2]): row[3]
+        for row in conn.execute("SELECT location_id, is_f2p, activity_id, id FROM world_details")}
+
+    data_to_insert = []
+    for w in world_data_list:
+        loc_id = _intern(conn, location_map, 'locations', 'name', w['location'])
+        act_id = _intern(conn, activity_map, 'activities', 'description', w['activity'])
+
+        detail_key = (loc_id, w['is_f2p'], act_id)
+        if detail_key not in details_map:
+            cursor = conn.execute(
+                "INSERT INTO world_details (location_id, is_f2p, activity_id) VALUES (?, ?, ?)",
+                (loc_id, w['is_f2p'], act_id)
+            )
+            details_map[detail_key] = cursor.lastrowid
+
+        data_to_insert.append(
+            (scrape_id, w['world_number'], w['player_count'], details_map[detail_key]))
+
+    conn.executemany(
+        "INSERT INTO world_data (scrape_id, world_number, player_count, detail_id) "
+        "VALUES (?, ?, ?, ?)",
+        data_to_insert
+    )
+
+
+def _save_round(conn, current_time, count, scrape_worlds, world_data_list):
+    """Persist one scrape round: the global count, plus world data when it's due.
+
+    A missing count or an empty world list is logged and skipped rather than
+    raised — a failed scrape shouldn't take the tracker down with it.
+    """
+    with conn:
+        if count:
+            conn.execute(
+                "INSERT INTO players (timestamp, count) VALUES (?, ?)",
+                (current_time, count)
+            )
+            logger.info(f"[{current_time}] Saved total count: {count:,}")
+        else:
+            logger.warning(f"[{current_time}] Failed to get total count.")
+
+        if not scrape_worlds:
+            return
+        if not world_data_list:
+            logger.warning(f"[{current_time}] Failed to get world data or list empty.")
+            return
+
+        logger.info(f"[{current_time}] Saving data for {len(world_data_list)} worlds...")
+        cursor = conn.execute(
+            "INSERT INTO scrape_events (timestamp) VALUES (?)", (current_time,))
+        _save_world_data(conn, cursor.lastrowid, world_data_list)
+        logger.info(f"[{current_time}] Saved world data.")
+
+
 def main():
     # 1. Initialize Database
     conn = init_db()
     logger.info(f"Bot started. Saving to: {os.path.abspath(DB_PATH)}")
-    
+
     # Track last world scrape time
     last_world_scrape = 0
 
@@ -124,111 +202,35 @@ def main():
             # 2. Scrape Data
             # Always get total count
             count = get_osrs_count()
-            
+
             # Check if we should scrape worlds
             current_ts = time.time()
             scrape_worlds = (current_ts - last_world_scrape >= WORLD_SCRAPE_INTERVAL)
-            
+
             world_data_list = []
             if scrape_worlds:
                 world_data_list = get_world_data()
                 if world_data_list:
                     last_world_scrape = current_ts
-            
+
             # Store timezone-aware UTC timestamps in ISO 8601
-            current_time = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+            current_time = (datetime.datetime.now(datetime.timezone.utc)
+                            .replace(microsecond=0).isoformat().replace('+00:00', 'Z'))
 
             # 3. Save to Database
-            with conn:
-                if count:
-                    conn.execute(
-                        "INSERT INTO players (timestamp, count) VALUES (?, ?)",
-                        (current_time, count)
-                    )
-                    logger.info(f"[{current_time}] Saved total count: {count:,}")
-                else:
-                    logger.warning(f"[{current_time}] Failed to get total count.")
-                
-                if scrape_worlds:
-                    if world_data_list:
-                        logger.info(f"[{current_time}] Saving data for {len(world_data_list)} worlds...")
-                        
-                        # 0. Create Scrape Event
-                        cursor = conn.execute("INSERT INTO scrape_events (timestamp) VALUES (?)", (current_time,))
-                        scrape_id = cursor.lastrowid
-
-                        # Cache locations
-                        location_map = {}
-                        for row in conn.execute("SELECT name, id FROM locations"):
-                            location_map[row[0]] = row[1]
-
-                        # Cache activities
-                        activity_map = {}
-                        for row in conn.execute("SELECT description, id FROM activities"):
-                            activity_map[row[0]] = row[1]
-
-                        # Cache details (unique combos of loc_id, f2p, activity_id)
-                        details_map = {}
-                        for row in conn.execute("SELECT location_id, is_f2p, activity_id, id FROM world_details"):
-                            details_map[(row[0], bool(row[1]), row[2])] = row[3]
-
-                        data_to_insert = []
-
-                        for w in world_data_list:
-                            # 1. Handle Location
-                            loc_name = w['location']
-                            if loc_name not in location_map:
-                                cursor = conn.execute("INSERT INTO locations (name) VALUES (?)", (loc_name,))
-                                location_map[loc_name] = cursor.lastrowid
-                            
-                            loc_id = location_map[loc_name]
-
-                            # 2. Handle Activity
-                            act_desc = w['activity']
-                            if act_desc not in activity_map:
-                                cursor = conn.execute("INSERT INTO activities (description) VALUES (?)", (act_desc,))
-                                activity_map[act_desc] = cursor.lastrowid
-                            
-                            act_id = activity_map[act_desc]
-                            
-                            # 3. Handle Details (The unique combo)
-                            detail_key = (loc_id, w['is_f2p'], act_id)
-                            
-                            if detail_key not in details_map:
-                                cursor = conn.execute(
-                                    "INSERT INTO world_details (location_id, is_f2p, activity_id) VALUES (?, ?, ?)", 
-                                    (loc_id, w['is_f2p'], act_id)
-                                )
-                                details_map[detail_key] = cursor.lastrowid
-                            
-                            detail_id = details_map[detail_key]
-
-                            # 4. Prepare Data
-                            data_to_insert.append((
-                                scrape_id, 
-                                w['world_number'], 
-                                w['player_count'],
-                                detail_id
-                            ))
-
-                        conn.executemany(
-                            "INSERT INTO world_data (scrape_id, world_number, player_count, detail_id) VALUES (?, ?, ?, ?)",
-                            data_to_insert
-                        )
-                        logger.info(f"[{current_time}] Saved world data.")
-                    else:
-                        logger.warning(f"[{current_time}] Failed to get world data or list empty.")
+            _save_round(conn, current_time, count, scrape_worlds, world_data_list)
 
         except Exception as e:
             logger.critical(f"Critical Error in loop: {e}")
             # Try to reconnect to DB if something broke the connection
             try:
                 conn = init_db()
-            except:
-                pass
+            except Exception as reconnect_error:
+                logger.error(f"Reconnect failed: {reconnect_error}")
 
         # 4. Wait for the configured interval
         time.sleep(SCRAPE_INTERVAL)
+
 
 if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 127
+max-complexity = 10
+exclude = .venv,.git,__pycache__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,334 @@
+"""API tests for osrs_api, against a synthetic database.
+
+These pin the response shapes the frontend depends on: the two branches of
+/api/history (global `players` vs. filtered `world_data`), the imported-era
+splice, and the aligned-series contract of /api/history/grouped. They exist so
+those endpoints can be refactored without guessing at what changed.
+
+The fixture DB is tiny and deterministic — 6 scrapes, 4 worlds — so expected
+values are written out by hand rather than computed the same way the code does.
+"""
+import os
+import sqlite3
+import tempfile
+import unittest
+
+import database
+
+
+# 6 scrapes, 10 minutes apart. Kept well in the past so no test depends on `now`.
+SCRAPE_TIMES = [
+    '2026-01-05T00:00:00Z',
+    '2026-01-05T00:10:00Z',
+    '2026-01-05T00:20:00Z',
+    '2026-01-05T01:00:00Z',
+    '2026-01-05T01:10:00Z',
+    '2026-01-06T00:00:00Z',
+]
+
+# world -> (location_id, is_f2p, player counts across the 6 scrapes)
+WORLDS = {
+    301: (1, 0, [100, 110, 120, 130, 140, 150]),
+    302: (1, 1, [10, 20, 30, 40, 50, 60]),
+    303: (2, 0, [200, 210, 220, 230, 240, 250]),
+    304: (2, 1, [5, 5, 5, 5, 5, 5]),
+}
+
+# Global `players` samples — deliberately NOT the sum of the world counts, so a
+# test that reads the wrong table fails loudly instead of coincidentally passing.
+PLAYER_COUNTS = [1000, 1100, 1200, 1300, 1400, 1500]
+
+
+def build_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript('''
+        CREATE TABLE players (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME, count INTEGER);
+        CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE);
+        CREATE TABLE activities (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT UNIQUE);
+        CREATE TABLE world_details (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, location_id INTEGER, is_f2p BOOLEAN,
+            activity_id INTEGER, UNIQUE(location_id, is_f2p, activity_id));
+        CREATE TABLE scrape_events (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME UNIQUE);
+        CREATE TABLE world_data (
+            scrape_id INTEGER, world_number INTEGER, player_count INTEGER, detail_id INTEGER,
+            PRIMARY KEY (scrape_id, world_number)) WITHOUT ROWID;
+        CREATE TABLE history_import (
+            period_start DATETIME, period_end DATETIME, stat TEXT, count INTEGER, source TEXT,
+            PRIMARY KEY (period_start, stat, source));
+    ''')
+
+    conn.executemany('INSERT INTO locations (id, name) VALUES (?, ?)',
+                     [(1, 'United States'), (2, 'Germany')])
+    conn.execute("INSERT INTO activities (id, description) VALUES (1, '-')")
+
+    # One world_details row per (location, f2p) pair the worlds actually use.
+    detail_ids = {}
+    for world, (loc, f2p, _) in WORLDS.items():
+        key = (loc, f2p)
+        if key not in detail_ids:
+            cur = conn.execute(
+                'INSERT INTO world_details (location_id, is_f2p, activity_id) VALUES (?, ?, 1)', key)
+            detail_ids[key] = cur.lastrowid
+
+    for i, ts in enumerate(SCRAPE_TIMES, start=1):
+        conn.execute('INSERT INTO scrape_events (id, timestamp) VALUES (?, ?)', (i, ts))
+        conn.execute('INSERT INTO players (timestamp, count) VALUES (?, ?)',
+                     (ts, PLAYER_COUNTS[i - 1]))
+        for world, (loc, f2p, counts) in WORLDS.items():
+            conn.execute(
+                'INSERT INTO world_data (scrape_id, world_number, player_count, detail_id) '
+                'VALUES (?, ?, ?, ?)', (i, world, counts[i - 1], detail_ids[(loc, f2p)]))
+
+    conn.commit()
+    conn.close()
+
+
+class ApiTestCase(unittest.TestCase):
+    """Points osrs_api at a temp DB and gives each test a Flask test client."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.db_path = os.path.join(cls._tmp.name, 'test.db')
+        build_db(cls.db_path)
+
+        # get_db_connection reads database.DB_PATH at call time, and osrs_api
+        # calls through to it, so patching the one global covers both.
+        cls._real_db_path = database.DB_PATH
+        database.DB_PATH = cls.db_path
+
+        import osrs_api
+        cls.osrs_api = osrs_api
+        osrs_api.app.config['TESTING'] = True
+
+    @classmethod
+    def tearDownClass(cls):
+        database.DB_PATH = cls._real_db_path
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.client = self.osrs_api.app.test_client()
+
+    def get(self, path):
+        resp = self.client.get(path)
+        return resp.status_code, resp.get_json()
+
+    def clear_imports(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute('DELETE FROM history_import')
+        conn.commit()
+        conn.close()
+
+
+class LatestTest(ApiTestCase):
+    """/api/latest and its F2P/members breakdown."""
+
+    def test_latest_is_the_final_scrape(self):
+        status, body = self.get('/api/latest')
+        self.assertEqual(status, 200)
+        self.assertEqual(body['timestamp'], SCRAPE_TIMES[-1])
+        self.assertEqual(body['count'], 1500)
+
+    def test_breakdown_splits_by_f2p(self):
+        _, body = self.get('/api/latest')
+        # Final scrape: f2p worlds 302 + 304 = 60 + 5; members 301 + 303 = 150 + 250.
+        self.assertEqual(body['f2p_count'], 65)
+        self.assertEqual(body['members_count'], 400)
+        self.assertEqual(body['breakdown_timestamp'], SCRAPE_TIMES[-1])
+
+
+class HistoryGlobalTest(ApiTestCase):
+    """/api/history against the `players` table — the no-filter branch."""
+
+    def setUp(self):
+        super().setUp()
+        self.clear_imports()
+
+    def test_raw_rows_are_ascending(self):
+        status, body = self.get('/api/history?start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual(status, 200)
+        self.assertEqual([r['timestamp'] for r in body], SCRAPE_TIMES)
+        self.assertEqual([r['count'] for r in body], PLAYER_COUNTS)
+
+    def test_limit_returns_the_most_recent_n_still_ascending(self):
+        _, body = self.get('/api/history?limit=2')
+        self.assertEqual([r['count'] for r in body], [1400, 1500])
+
+    def test_hourly_max(self):
+        _, body = self.get('/api/history?unit=hour&start=2026-01-05T00:00:00Z&end=2026-01-05T23:59:59Z')
+        self.assertEqual(body, [
+            {'timestamp': '2026-01-05T00:00:00Z', 'count': 1200},
+            {'timestamp': '2026-01-05T01:00:00Z', 'count': 1400},
+        ])
+
+    def test_hourly_avg_rounds(self):
+        _, body = self.get(
+            '/api/history?unit=hour&agg=avg&start=2026-01-05T00:00:00Z&end=2026-01-05T23:59:59Z')
+        # (1000+1100+1200)/3 = 1100, (1300+1400)/2 = 1350
+        self.assertEqual([r['count'] for r in body], [1100, 1350])
+
+    def test_range_filters_are_inclusive(self):
+        _, body = self.get('/api/history?start=2026-01-05T00:10:00Z&end=2026-01-05T01:00:00Z')
+        self.assertEqual([r['count'] for r in body], [1100, 1200, 1300])
+
+    def test_minute_span_over_30_days_is_rejected(self):
+        status, body = self.get(
+            '/api/history?unit=minute&step=5&start=2026-01-01T00:00:00Z&end=2026-06-01T00:00:00Z')
+        self.assertEqual(status, 400)
+        self.assertIn('30 days', body['error'])
+
+
+class HistoryImportedEraTest(ApiTestCase):
+    """The imported weekly series is prepended, and the native query is floored."""
+
+    def setUp(self):
+        super().setUp()
+        conn = sqlite3.connect(self.db_path)
+        conn.execute('DELETE FROM history_import')
+        conn.executemany(
+            'INSERT INTO history_import (period_start, period_end, stat, count, source) '
+            'VALUES (?, ?, ?, ?, ?)',
+            [('2025-12-15T00:00:00Z', '2025-12-22T00:00:00Z', 'peak', 900, 'mi'),
+             ('2025-12-15T00:00:00Z', '2025-12-22T00:00:00Z', 'avg', 800, 'mi'),
+             ('2025-12-22T00:00:00Z', '2025-12-29T00:00:00Z', 'peak', 950, 'mi'),
+             ('2025-12-22T00:00:00Z', '2025-12-29T00:00:00Z', 'avg', 850, 'mi')])
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        self.clear_imports()
+
+    def test_imported_rows_precede_native_rows(self):
+        _, body = self.get('/api/history?start=2025-12-01T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], [900, 950] + PLAYER_COUNTS)
+
+    def test_agg_avg_selects_the_avg_statistic(self):
+        _, body = self.get('/api/history?agg=avg&start=2025-12-01T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body][:2], [800, 850])
+
+    def test_bare_limit_call_skips_the_imported_era(self):
+        _, body = self.get('/api/history?limit=2')
+        self.assertEqual([r['count'] for r in body], [1400, 1500])
+
+
+class HistoryWorldDataTest(ApiTestCase):
+    """/api/history with a filter — the world_data branch."""
+
+    def test_single_world_returns_its_own_counts(self):
+        _, body = self.get(
+            '/api/history?world_id=301&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], WORLDS[301][2])
+
+    def test_location_sums_within_each_scrape(self):
+        _, body = self.get(
+            '/api/history?location_id=1&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        # Worlds 301 + 302 at each scrape.
+        self.assertEqual([r['count'] for r in body], [110, 130, 150, 170, 190, 210])
+
+    def test_f2p_filter_sums_only_f2p_worlds(self):
+        _, body = self.get(
+            '/api/history?is_f2p=1&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        # Worlds 302 + 304.
+        self.assertEqual([r['count'] for r in body], [15, 25, 35, 45, 55, 65])
+
+    def test_location_and_f2p_combine(self):
+        _, body = self.get(
+            '/api/history?location_id=2&is_f2p=0&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], WORLDS[303][2])
+
+    def test_bucketing_aggregates_across_time_not_within_it(self):
+        # Hourly max of a summed series: the sum happens per scrape first, then
+        # MAX across the scrapes in the hour. Collapsing the two would give 450.
+        _, body = self.get(
+            '/api/history?location_id=1&unit=hour'
+            '&start=2026-01-05T00:00:00Z&end=2026-01-05T23:59:59Z')
+        self.assertEqual([r['count'] for r in body], [150, 190])
+
+    def test_range_outside_all_scrapes_is_empty(self):
+        status, body = self.get(
+            '/api/history?world_id=301&start=2020-01-01T00:00:00Z&end=2020-01-02T00:00:00Z')
+        self.assertEqual(status, 200)
+        self.assertEqual(body, [])
+
+
+class HistoryGroupedTest(ApiTestCase):
+    """/api/history/grouped — the aligned timestamps/series contract."""
+
+    RANGE = 'start=2026-01-05T00:00:00Z&end=2026-01-05T23:59:59Z'
+
+    def test_unit_is_required(self):
+        status, body = self.get(f'/api/history/grouped?{self.RANGE}')
+        self.assertEqual(status, 400)
+        self.assertIn('unit', body['error'])
+
+    def test_unknown_group_by_is_rejected(self):
+        status, body = self.get(f'/api/history/grouped?group_by=nope&unit=hour&{self.RANGE}')
+        self.assertEqual(status, 400)
+        self.assertIn('group_by', body['error'])
+
+    def test_start_after_end_is_rejected(self):
+        status, _ = self.get(
+            '/api/history/grouped?unit=hour&start=2026-02-01T00:00:00Z&end=2026-01-01T00:00:00Z')
+        self.assertEqual(status, 400)
+
+    def test_group_by_world_gives_one_series_per_world(self):
+        status, body = self.get(f'/api/history/grouped?group_by=world&unit=hour&{self.RANGE}')
+        self.assertEqual(status, 200)
+        self.assertEqual(body['timestamps'],
+                         ['2026-01-05T00:00:00Z', '2026-01-05T01:00:00Z'])
+        self.assertEqual([s['key'] for s in body['series']], [301, 302, 303, 304])
+        by_key = {s['key']: s['counts'] for s in body['series']}
+        self.assertEqual(by_key[301], [120, 140])
+        self.assertEqual(by_key[304], [5, 5])
+
+    def test_group_by_location_sums_within_each_scrape(self):
+        _, body = self.get(f'/api/history/grouped?group_by=location&unit=hour&{self.RANGE}')
+        by_key = {s['key']: s['counts'] for s in body['series']}
+        self.assertEqual(by_key[1], [150, 190])   # worlds 301 + 302
+        self.assertEqual(by_key[2], [225, 245])   # worlds 303 + 304
+
+    def test_group_by_f2p_sums_within_each_scrape(self):
+        _, body = self.get(f'/api/history/grouped?group_by=f2p&unit=hour&{self.RANGE}')
+        by_key = {s['key']: s['counts'] for s in body['series']}
+        self.assertEqual(by_key[0], [340, 380])   # worlds 301 + 303
+        self.assertEqual(by_key[1], [35, 55])     # worlds 302 + 304
+
+    def test_every_series_is_aligned_to_timestamps(self):
+        _, body = self.get(f'/api/history/grouped?group_by=world&unit=hour&{self.RANGE}')
+        for s in body['series']:
+            self.assertEqual(len(s['counts']), len(body['timestamps']), s['key'])
+
+    def test_filters_narrow_the_series_set(self):
+        _, body = self.get(
+            f'/api/history/grouped?group_by=world&unit=hour&is_f2p=1&{self.RANGE}')
+        self.assertEqual([s['key'] for s in body['series']], [302, 304])
+
+    def test_range_outside_all_scrapes_is_empty(self):
+        status, body = self.get(
+            '/api/history/grouped?group_by=world&unit=hour'
+            '&start=2020-01-01T00:00:00Z&end=2020-01-02T00:00:00Z')
+        self.assertEqual(status, 200)
+        self.assertEqual(body, {'timestamps': [], 'series': []})
+
+    def test_over_the_point_cap_is_rejected(self):
+        real = self.osrs_api.MAX_GROUPED_POINTS
+        self.osrs_api.MAX_GROUPED_POINTS = 1
+        try:
+            status, body = self.get(f'/api/history/grouped?group_by=world&unit=hour&{self.RANGE}')
+            self.assertEqual(status, 400)
+            self.assertIn('Too many points', body['error'])
+        finally:
+            self.osrs_api.MAX_GROUPED_POINTS = real
+
+
+class MetadataTest(ApiTestCase):
+    def test_metadata_lists_locations_and_worlds(self):
+        status, body = self.get('/api/metadata')
+        self.assertEqual(status, 200)
+        self.assertEqual(sorted(loc['name'] for loc in body['locations']),
+                         ['Germany', 'United States'])
+        self.assertEqual(sorted(body['worlds']), [301, 302, 303, 304])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,127 @@
+"""Tests for the tracker's database write path.
+
+parse_world_data is covered in test_parsers; this covers what happens to the
+rows afterwards — the interning of locations, activities and world_details, and
+the world_data rows they end up pointing at.
+"""
+import sqlite3
+import unittest
+
+from rs_tracker import _intern, _save_world_data
+
+
+def world(number, count, location, f2p, activity):
+    return {'world_number': number, 'player_count': count,
+            'location': location, 'is_f2p': f2p, 'activity': activity}
+
+
+class SaveWorldDataTest(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.executescript('''
+            CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE);
+            CREATE TABLE activities (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT UNIQUE);
+            CREATE TABLE world_details (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, location_id INTEGER, is_f2p BOOLEAN,
+                activity_id INTEGER, UNIQUE(location_id, is_f2p, activity_id));
+            CREATE TABLE scrape_events (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp DATETIME UNIQUE);
+            CREATE TABLE world_data (
+                scrape_id INTEGER, world_number INTEGER, player_count INTEGER, detail_id INTEGER,
+                PRIMARY KEY (scrape_id, world_number)) WITHOUT ROWID;
+        ''')
+
+    def tearDown(self):
+        self.conn.close()
+
+    def rows(self, sql):
+        return self.conn.execute(sql).fetchall()
+
+    def test_writes_one_row_per_world(self):
+        _save_world_data(self.conn, 1, [
+            world(301, 100, 'United States', False, '-'),
+            world(302, 50, 'Germany', True, 'Blast Furnace'),
+        ])
+        self.assertEqual(
+            self.rows('SELECT world_number, player_count FROM world_data ORDER BY world_number'),
+            [(301, 100), (302, 50)])
+
+    def test_new_locations_and_activities_are_created_once(self):
+        batch = [world(301, 100, 'United States', False, '-'),
+                 world(302, 110, 'United States', False, '-'),
+                 world(303, 120, 'Germany', False, '-')]
+        _save_world_data(self.conn, 1, batch)
+        self.assertEqual(sorted(r[0] for r in self.rows('SELECT name FROM locations')),
+                         ['Germany', 'United States'])
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM activities')[0][0], 1)
+
+    def test_details_are_reused_across_scrapes(self):
+        batch = [world(301, 100, 'United States', False, '-')]
+        _save_world_data(self.conn, 1, batch)
+        self.conn.execute('INSERT INTO scrape_events (id, timestamp) VALUES (2, ?)', ('t2',))
+        _save_world_data(self.conn, 2, batch)
+
+        # The second scrape must not create a duplicate location/activity/detail.
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM locations')[0][0], 1)
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM activities')[0][0], 1)
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM world_details')[0][0], 1)
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM world_data')[0][0], 2)
+
+    def test_distinct_combinations_get_distinct_details(self):
+        _save_world_data(self.conn, 1, [
+            world(301, 100, 'United States', False, '-'),
+            world(302, 100, 'United States', True, '-'),
+            world(303, 100, 'United States', False, 'Blast Furnace'),
+        ])
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM world_details')[0][0], 3)
+        detail_ids = [r[0] for r in self.rows('SELECT detail_id FROM world_data')]
+        self.assertEqual(len(set(detail_ids)), 3)
+
+    def test_world_data_points_at_the_right_detail(self):
+        _save_world_data(self.conn, 1, [
+            world(301, 100, 'United States', False, '-'),
+            world(302, 50, 'Germany', True, 'Blast Furnace'),
+        ])
+        joined = self.rows('''
+            SELECT wd.world_number, loc.name, det.is_f2p, act.description
+            FROM world_data wd
+            JOIN world_details det ON wd.detail_id = det.id
+            JOIN locations loc ON det.location_id = loc.id
+            JOIN activities act ON det.activity_id = act.id
+            ORDER BY wd.world_number
+        ''')
+        self.assertEqual(joined, [(301, 'United States', 0, '-'),
+                                  (302, 'Germany', 1, 'Blast Furnace')])
+
+    def test_empty_batch_writes_nothing(self):
+        _save_world_data(self.conn, 1, [])
+        self.assertEqual(self.rows('SELECT COUNT(*) FROM world_data')[0][0], 0)
+
+
+class InternTest(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.execute(
+            'CREATE TABLE locations (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)')
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_inserts_once_and_caches(self):
+        cache = {}
+        first = _intern(self.conn, cache, 'locations', 'name', 'Japan')
+        second = _intern(self.conn, cache, 'locations', 'name', 'Japan')
+        self.assertEqual(first, second)
+        self.assertEqual(cache, {'Japan': first})
+        self.assertEqual(self.conn.execute('SELECT COUNT(*) FROM locations').fetchone()[0], 1)
+
+    def test_a_seeded_value_is_not_reinserted(self):
+        self.conn.execute("INSERT INTO locations (id, name) VALUES (7, 'Japan')")
+        cache = {'Japan': 7}
+        self.assertEqual(_intern(self.conn, cache, 'locations', 'name', 'Japan'), 7)
+        self.assertEqual(self.conn.execute('SELECT COUNT(*) FROM locations').fetchone()[0], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/make_dump.py
+++ b/tools/make_dump.py
@@ -453,7 +453,7 @@ def publish(token, tag, title, body, assets, draft=False):
 
 # --------------------------------------------------------------------------
 
-def main():
+def build_parser():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--db", default=None,
                         help="path to the live database (default: from config.py)")
@@ -480,12 +480,11 @@ def main():
     parser.add_argument("--keep-artifacts", action="store_true",
                         help="keep the local asset files after a successful "
                              "publish instead of deleting them")
-    args = parser.parse_args()
+    return parser
 
-    if sqlite3.sqlite_version_info < MIN_SQLITE:
-        die("SQLite %s is too old; need %s or newer for VACUUM INTO"
-            % (sqlite3.sqlite_version, ".".join(str(n) for n in MIN_SQLITE)))
 
+def resolve_db_path(args):
+    """The database to dump, defaulting to the app's own config."""
     db_path = args.db
     if db_path is None:
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -493,33 +492,18 @@ def main():
         db_path = DB_PATH
     if not os.path.exists(db_path):
         die("no database at %s" % db_path)
+    return db_path
 
-    token = read_token(args)
-    if not args.dry_run and not token:
-        die("No token. Set GITHUB_TOKEN or pass --token-file. Use --dry-run to "
-            "build artifacts without publishing.")
 
-    now = dt.datetime.now(dt.timezone.utc)
-    date_str = now.strftime("%Y-%m-%d")
-    generated_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    tag = "data-%s" % date_str
+def build_artifacts(args, db_path, date_str, generated_at, snap, csv_path):
+    """Build the compressed snapshot and the CSV. Returns (gz_name, gz_path,
+    stats, csv_rows).
 
+    The intermediate uncompressed snapshot is the expensive thing on a quota'd
+    host, so its removal goes in a finally -- a failed build must not strand
+    ~100 MB until someone notices.
+    """
     out = args.out_dir
-    if not os.path.isdir(out):
-        os.makedirs(out)
-
-    db_name = "osrs_data-%s.db" % date_str
-    snap = os.path.join(out, db_name)
-    csv_name = "osrs_global-%s.csv" % date_str
-    csv_path = os.path.join(out, csv_name)
-
-    if not args.dry_run:
-        log("Checking release interval...")
-        check_release_interval(token, args.force, args.if_due)
-
-    # The intermediate uncompressed snapshot is the expensive thing on a quota'd
-    # host, so its removal goes in a finally -- a failed upload must not strand
-    # ~100 MB until someone notices.
     try:
         if args.strategy == "iterdump":
             gz_name = "osrs_data-%s.sql.gz" % date_str
@@ -541,6 +525,7 @@ def main():
                               build_meta_rows(generated_at, stats))
             log("  wrote %s" % human(os.path.getsize(gz_path)))
         else:
+            db_name = os.path.basename(snap)
             gz_name = db_name + ".gz"
             gz_path = os.path.join(out, gz_name)
 
@@ -569,29 +554,18 @@ def main():
         if os.path.exists(snap):
             os.remove(snap)
 
-    assets = [
-        (gz_name, gz_path, sha256(gz_path)),
-        (csv_name, csv_path, sha256(csv_path)),
-    ]
-    body = render_notes(date_str, stats, assets, csv_rows)
-    # Date first so releases sort and scan by date in the GitHub releases list.
-    title = "%s — OSRS player count data" % date_str
+    return gz_name, gz_path, stats, csv_rows
 
-    notes_path = os.path.join(out, "release-notes-%s.md" % date_str)
-    with open(notes_path, "w", encoding="utf-8") as fh:
-        fh.write(body)
 
-    if args.dry_run:
-        log("")
-        log("Dry run. Nothing published. Artifacts:")
-        for name, path, digest in assets:
-            log("  %s  %s  %s" % (name, human(os.path.getsize(path)), digest))
-        log("  %s" % notes_path)
-        return
+def report_dry_run(assets, notes_path):
+    log("")
+    log("Dry run. Nothing published. Artifacts:")
+    for name, path, digest in assets:
+        log("  %s  %s  %s" % (name, human(os.path.getsize(path)), digest))
+    log("  %s" % notes_path)
 
-    log("Publishing %s%s..." % (tag, " (draft)" if args.draft else ""))
-    url = publish(token, tag, title, body, assets, draft=args.draft)
 
+def report_published(args, tag, url, assets):
     # GitHub now holds the only copies that matter. Left in place these would
     # accumulate ~40 MB per run against a quota'd host.
     if not args.keep_artifacts:
@@ -605,6 +579,62 @@ def main():
         log("Discard it with:  gh release delete %s --yes" % tag)
     else:
         log("Published: %s" % url)
+
+
+def main():
+    args = build_parser().parse_args()
+
+    if sqlite3.sqlite_version_info < MIN_SQLITE:
+        die("SQLite %s is too old; need %s or newer for VACUUM INTO"
+            % (sqlite3.sqlite_version, ".".join(str(n) for n in MIN_SQLITE)))
+
+    db_path = resolve_db_path(args)
+
+    token = read_token(args)
+    if not args.dry_run and not token:
+        die("No token. Set GITHUB_TOKEN or pass --token-file. Use --dry-run to "
+            "build artifacts without publishing.")
+
+    now = dt.datetime.now(dt.timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+    generated_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    tag = "data-%s" % date_str
+
+    out = args.out_dir
+    if not os.path.isdir(out):
+        os.makedirs(out)
+
+    db_name = "osrs_data-%s.db" % date_str
+    snap = os.path.join(out, db_name)
+    csv_name = "osrs_global-%s.csv" % date_str
+    csv_path = os.path.join(out, csv_name)
+
+    if not args.dry_run:
+        log("Checking release interval...")
+        check_release_interval(token, args.force, args.if_due)
+
+    gz_name, gz_path, stats, csv_rows = build_artifacts(
+        args, db_path, date_str, generated_at, snap, csv_path)
+
+    assets = [
+        (gz_name, gz_path, sha256(gz_path)),
+        (csv_name, csv_path, sha256(csv_path)),
+    ]
+    body = render_notes(date_str, stats, assets, csv_rows)
+    # Date first so releases sort and scan by date in the GitHub releases list.
+    title = "%s — OSRS player count data" % date_str
+
+    notes_path = os.path.join(out, "release-notes-%s.md" % date_str)
+    with open(notes_path, "w", encoding="utf-8") as fh:
+        fh.write(body)
+
+    if args.dry_run:
+        report_dry_run(assets, notes_path)
+        return
+
+    log("Publishing %s%s..." % (tag, " (draft)" if args.draft else ""))
+    url = publish(token, tag, title, body, assets, draft=args.draft)
+    report_published(args, tag, url, assets)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The cleanup pass #13 deferred. `flake8` now runs blocking in CI with zero violations and zero `noqa` suppressions.

The 84 violations split into an easy 80 and a real 4. The easy ones are mechanical. The four `C901` hits are the actual content of this PR, because getting under the threshold meant restructuring `get_history` — which #13 flagged as "~240 lines with two near-parallel query builders" and the thing that would fight the next feature.

## What's here

- **`setup.cfg` holds the lint settings**, so a bare `flake8` locally matches CI exactly instead of needing the flags remembered. `ci.yml` drops `--exit-zero` and the duplicated flags.
- **The 80 mechanical fixes** — whitespace, blank lines, seven wrapped lines. Two error strings that appeared twice each became `TOO_MANY_POINTS_MSG` / `MINUTE_SPAN_MSG`.
- **The bare `except:`** in the tracker's reconnect path now catches `Exception` and logs the failure instead of silently swallowing it.
- **`get_history` 33 → 3.** Split into a `HistoryQuery` dataclass for the parsed params plus `_world_history` / `_global_history` for the two branches, which never shared state — the route is now a 12-line dispatch.
- **`get_history_grouped` 19 → 5**, into `_grouped_error` / `_grouped_over_cap` / `_grouped_query` / `_align_series`.
- **`rs_tracker.main` 18 → 4.** The three identical lookup-or-insert stanzas collapse into `_intern`; the persistence block becomes `_save_round` / `_save_world_data`.
- **`make_dump.main` 14 → 6**, into `build_parser` / `resolve_db_path` / `build_artifacts` / `report_*`.

The two endpoints now parse into the same object and share `_world_detail_clauses`, which is what makes the planned activity filter one field and one clause across both rather than a parallel edit in each.

## Verification

The endpoints had no test coverage at all, so the refactor got a safety net before it got touched — that's the first commit, deliberately separate:

- **30 API tests against a synthetic 6-scrape database**, written first and verified green against the *unmodified* `osrs_api.py`. They pin both branches, every unit, both agg modes, the imported-era splice, and the aligned-series contract. Two of my own expected values were wrong on the first run and the old code caught them, which is the right direction for that to fail.
- **8 tests for the tracker's write path** (`_save_world_data`, `_intern`), which was previously untestable without running the loop.
- **Differential test of HEAD vs. refactored across 45 query shapes against the real 116 MB production database** — both branches, all units, all filter combinations, error paths, empty ranges. Byte-identical JSON on all 45.
- **`make_dump --dry-run` on both `vacuum` and `iterdump`**, producing identical artifacts.
- **Both CI steps re-run in a clean `git archive` checkout with a fresh venv and no `osrs_data.db`**, confirming the new tests don't depend on a local database.

58 tests total, stdlib `unittest`, no new dependency. Each commit is independently green.

## One intentional behaviour change

`/api/history?unit=minute&step=N&start=…` with no `end` returned a truncated `"Minute-level queries cannot span more than 30 days."` while the start+end path returned the full sentence. Both now return the full message. Same status, same meaning — it was an inconsistency, not a distinction.

## Not in scope

`make_dump` crashes in `render_notes` on a database with no `history_import` rows — it indexes `stats["import_range"][0]` unconditionally. Confirmed byte-identical to `main`, so it predates this branch; prod never hits it because the real database has imports. Left alone rather than smuggled into a lint PR. Two-line guard whenever it's wanted.
