### PR TITLE
Add an activity filter with display-only grouping

### DIFF
--- a/activities.py
+++ b/activities.py
@@ -1,0 +1,71 @@
+"""Display-only grouping of the SLU activity strings.
+
+Jagex publishes activities as free text, so one real activity reaches us under
+several names: `Castle Wars 1`, `Castle Wars 2`, `Castle Wars - Free`. The
+database keeps every string exactly as scraped; grouping happens here, on the
+way out, so the stored rows and the data dump stay faithful to the source.
+"""
+
+# The no-activity bucket. 179 worlds carry it, which makes it both meaningless
+# as a filter and by far the largest entry, so it never reaches the dropdown.
+NO_ACTIVITY = '-'
+
+# Families that arrive under several names. A description belongs to a prefix
+# when it equals the prefix or continues it after a space or dash, so
+# `Event PvP World` never joins `PvP World`. Matched longest-first, which is
+# what keeps `Deadman Finale - 96+` out of `Deadman`.
+ACTIVITY_GROUP_PREFIXES = (
+    'Brimhaven Agility',
+    'Castle Wars',
+    'Deadman',
+    'Deadman Finale',
+    'LMS',
+    'Leagues VI',
+    'PvP Arena',
+    'PvP World',
+    'Trade',
+    'Wilderness PK',
+)
+
+
+def _family_prefix(description, ordered_prefixes):
+    for prefix in ordered_prefixes:
+        if description == prefix:
+            return prefix
+        if description.startswith(prefix) and description[len(prefix)] in ' -':
+            return prefix
+    return None
+
+
+def group_activities(activities):
+    """[(id, description)] -> [{"name": str, "ids": [int]}] for the filter UI.
+
+    Members of a known family collapse into one entry carrying every member id;
+    everything else is its own entry. A family that turns out to have a single
+    member keeps that member's full description — there is nothing to merge, and
+    the specific name says more than the prefix.
+
+    Grouped ids span every era the members existed in, so a family whose members
+    retired at different times steps down as they drop out. That is what the
+    data says; it is not an outage.
+    """
+    ordered = sorted(ACTIVITY_GROUP_PREFIXES, key=len, reverse=True)
+
+    families, entries = {}, []
+    for activity_id, description in activities:
+        if description == NO_ACTIVITY:
+            continue
+        prefix = _family_prefix(description, ordered)
+        if prefix is None:
+            entries.append((description, [activity_id]))
+        else:
+            families.setdefault(prefix, []).append((description, activity_id))
+
+    for prefix, members in families.items():
+        if len(members) == 1:
+            entries.append((members[0][0], [members[0][1]]))
+        else:
+            entries.append((prefix, sorted(member_id for _, member_id in members)))
+
+    return [{"name": name, "ids": ids}
+            for name, ids in sorted(entries, key=lambda entry: entry[0].lower())]

--- a/osrs_api.py
+++ b/osrs_api.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
 
+from activities import group_activities
 from config import BASE_DIR
 from database import get_db_connection
 
@@ -123,6 +124,10 @@ def get_metadata():
         return jsonify({
             "locations": [{"id": row['id'], "name": row['name']} for row in locations],
             "activities": [{"id": row['id'], "description": row['description']} for row in activities],
+            # Raw descriptions above, the dropdown's collapsed view here. The UI
+            # wants the second; anything reading the source strings wants the first.
+            "activity_groups": group_activities(
+                (row['id'], row['description']) for row in activities),
             "worlds": [row['world_number'] for row in worlds]
         })
     finally:
@@ -262,15 +267,20 @@ def _scrape_id_bounds(conn, start_dt, end_dt):
     return lo, hi
 
 
-def _world_detail_clauses(location_id, is_f2p):
+def _world_detail_clauses(q):
     """(clauses, params) for the world_details filters shared by both endpoints."""
     clauses, params = [], []
-    if location_id is not None:
+    if q.location_id is not None:
         clauses.append("det.location_id = ?")
-        params.append(location_id)
-    if is_f2p is not None:
+        params.append(q.location_id)
+    if q.is_f2p is not None:
         clauses.append("det.is_f2p = ?")
-        params.append(is_f2p)
+        params.append(q.is_f2p)
+    if q.activity_ids:
+        # A group selection arrives as every member id, so this is an IN even
+        # when the user picked one thing from the dropdown.
+        clauses.append(f"det.activity_id IN ({','.join('?' * len(q.activity_ids))})")
+        params.extend(q.activity_ids)
     return clauses, params
 
 
@@ -295,6 +305,33 @@ TOO_MANY_POINTS_MSG = ("Too many points for one comparison. "
 MINUTE_SPAN_MSG = ("Minute-level queries cannot span more than 30 days. "
                    "Please use a larger unit (hour/day) or a shorter time range.")
 
+# Bound on the IN list built from activity_id. The largest real group is 16
+# members, so this only ever rejects input no dropdown could have produced.
+MAX_ACTIVITY_IDS = 200
+
+TOO_MANY_ACTIVITIES_MSG = f"At most {MAX_ACTIVITY_IDS} activity_id values are allowed."
+
+
+def _parse_activity_ids(values):
+    """Repeated and/or comma-separated `activity_id` params -> unique ints.
+
+    Unparseable tokens are dropped rather than rejected, which is how `type=int`
+    already treats the other filters: a bad value means no filter, not a 400.
+    """
+    ids = []
+    for value in values:
+        for token in value.split(','):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                parsed = int(token)
+            except ValueError:
+                continue
+            if parsed not in ids:
+                ids.append(parsed)
+    return tuple(ids)
+
 
 @dataclass
 class HistoryQuery:
@@ -309,6 +346,7 @@ class HistoryQuery:
     world_id: int = None
     location_id: int = None
     is_f2p: int = None
+    activity_ids: tuple = ()
 
     @classmethod
     def from_request(cls):
@@ -322,6 +360,7 @@ class HistoryQuery:
             world_id=request.args.get('world_id', default=None, type=int),
             location_id=request.args.get('location_id', default=None, type=int),
             is_f2p=request.args.get('is_f2p', default=None, type=int),
+            activity_ids=_parse_activity_ids(request.args.getlist('activity_id')),
         )
 
     @property
@@ -329,10 +368,19 @@ class HistoryQuery:
         return "ROUND(AVG(count))" if self.agg == 'avg' else "MAX(count)"
 
     @property
+    def needs_details_join(self):
+        """Whether any filter reads world_details, and so needs it joined in."""
+        return (self.location_id is not None or self.is_f2p is not None
+                or bool(self.activity_ids))
+
+    @property
     def use_world_data(self):
         """Whether any filter forces the per-world tables instead of `players`."""
-        return (self.world_id is not None or self.location_id is not None
-                or self.is_f2p is not None)
+        return self.world_id is not None or self.needs_details_join
+
+    @property
+    def too_many_activities(self):
+        return len(self.activity_ids) > MAX_ACTIVITY_IDS
 
     @property
     def minute_span_exceeded(self):
@@ -348,7 +396,7 @@ def _world_history(conn, q):
     """One series from world_data: a single world's count, or the sum over the
     worlds matching the filters at each scrape."""
     from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
-    if q.location_id is not None or q.is_f2p is not None:
+    if q.needs_details_join:
         from_clause += " JOIN world_details det ON wd.detail_id = det.id"
 
     where_clauses, params = [], []
@@ -361,7 +409,7 @@ def _world_history(conn, q):
         select_clause = "SELECT se.timestamp as timestamp, SUM(wd.player_count) as count"
         group_by = "GROUP BY se.id"
 
-    detail_clauses, detail_params = _world_detail_clauses(q.location_id, q.is_f2p)
+    detail_clauses, detail_params = _world_detail_clauses(q)
     where_clauses += detail_clauses
     params += detail_params
 
@@ -459,6 +507,8 @@ def _grouped_error(q, group_by, buckets):
     """The 400 response for an unusable /api/history/grouped request, else None."""
     if group_by not in GROUPINGS:
         return jsonify({"error": f"group_by must be one of: {', '.join(GROUPINGS)}"}), 400
+    if q.too_many_activities:
+        return jsonify({"error": TOO_MANY_ACTIVITIES_MSG}), 400
     if not buckets:
         return jsonify({"error": "unit is required: minute, hour, day, week or month."}), 400
     if q.start_dt > q.end_dt:
@@ -485,7 +535,7 @@ def _grouped_query(q, group_by, buckets, lo, hi):
     key_expr, sum_within_scrape = GROUPINGS[group_by]
 
     from_clause = "FROM world_data wd JOIN scrape_events se ON wd.scrape_id = se.id"
-    if sum_within_scrape or q.location_id is not None or q.is_f2p is not None:
+    if sum_within_scrape or q.needs_details_join:
         from_clause += " JOIN world_details det ON wd.detail_id = det.id"
 
     where_clauses = ["wd.scrape_id >= ?", "wd.scrape_id <= ?"]
@@ -493,7 +543,7 @@ def _grouped_query(q, group_by, buckets, lo, hi):
     if q.world_id is not None:
         where_clauses.append("wd.world_number = ?")
         params.append(q.world_id)
-    detail_clauses, detail_params = _world_detail_clauses(q.location_id, q.is_f2p)
+    detail_clauses, detail_params = _world_detail_clauses(q)
     where_clauses += detail_clauses
     params += detail_params
     where_str = "WHERE " + " AND ".join(where_clauses)
@@ -551,7 +601,7 @@ def get_history_grouped():
     Query parameters:
         - group_by (str): 'world' (default), 'location' or 'f2p'.
         - start, end, unit, step, agg: as /api/history. unit is required.
-        - world_id, location_id, is_f2p: filters, as /api/history.
+        - world_id, location_id, is_f2p, activity_id: filters, as /api/history.
 
     Returns {"timestamps": [...], "series": [{"key": k, "counts": [n|null, ...]}]}
     where each counts array is aligned to timestamps by index.
@@ -607,10 +657,15 @@ def get_history():
         - world_id (int): Filter by specific world number.
         - location_id (int): Filter by location ID.
         - is_f2p (bool/int): Filter by F2P status (1=True, 0=False).
+        - activity_id (int): Filter by activity. Repeatable, and accepts a
+          comma-separated list, so one grouped dropdown entry can send every
+          member id at once. Multiple ids sum the worlds carrying any of them.
     """
     q = HistoryQuery.from_request()
     if q.minute_span_exceeded:
         return jsonify({"error": MINUTE_SPAN_MSG}), 400
+    if q.too_many_activities:
+        return jsonify({"error": TOO_MANY_ACTIVITIES_MSG}), 400
 
     conn = get_db_connection()
     try:

--- a/osrs_api.py
+++ b/osrs_api.py
@@ -105,6 +105,12 @@ def get_metadata():
         # Get Activities
         activities = conn.execute('SELECT id, description FROM activities ORDER BY description').fetchall()
 
+        # The floor on every filtered query. Before this the only history is the
+        # imported weekly series, which is site-wide with no per-world breakdown,
+        # so any filter silently starts here rather than where the user asked.
+        world_data_start = conn.execute(
+            'SELECT MIN(timestamp) FROM scrape_events').fetchone()[0]
+
         # Loose index scan over idx_world_number: one seek per world instead of
         # walking ~4M rows. Not SELECT DISTINCT, which is ~215ms here vs ~2ms.
         worlds = conn.execute('''
@@ -128,7 +134,8 @@ def get_metadata():
             # wants the second; anything reading the source strings wants the first.
             "activity_groups": group_activities(
                 (row['id'], row['description']) for row in activities),
-            "worlds": [row['world_number'] for row in worlds]
+            "worlds": [row['world_number'] for row in worlds],
+            "world_data_start": world_data_start
         })
     finally:
         conn.close()

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
 // Globals
 let populationChart = null;
 let rawHistory = []; // cache of last fetched raw points
-let globalMetadata = { locations: [], worlds: [] }; // Store metadata for comparison logic
+let globalMetadata = { locations: [], worlds: [], activity_groups: [] }; // Store metadata for comparison logic
 
 // Utility: format JS Date -> ISO used by datetime-local (without seconds)
 function toLocalInputISO(date) {
@@ -49,7 +49,15 @@ async function fetchMetadata() {
             locSelect.appendChild(opt);
         });
 
-        // Activities are available in data.activities if we want to add them later
+        // Populate Activities. Uses the pre-grouped list, not data.activities:
+        // the value is every member id of one dropdown entry, comma-separated.
+        const activitySelect = document.getElementById('activitySelect');
+        (data.activity_groups || []).forEach(group => {
+            const opt = document.createElement('option');
+            opt.value = group.ids.join(',');
+            opt.textContent = group.name;
+            activitySelect.appendChild(opt);
+        });
     } catch (error) {
         console.error('Error fetching metadata:', error);
     }
@@ -98,7 +106,7 @@ async function fetchLatest() {
 }
 
 // Fetch history from API with optional start/end (ISO) and unit/step for server-side aggregation
-async function fetchHistory({start=null, end=null, unit=null, step=null, limit=null, agg=null, world_id=null, location_id=null, is_f2p=null} = {}) {
+async function fetchHistory({start=null, end=null, unit=null, step=null, limit=null, agg=null, world_id=null, location_id=null, is_f2p=null, activity_id=null} = {}) {
     try {
         const params = new URLSearchParams();
         if (start) params.set('start', start);
@@ -111,6 +119,7 @@ async function fetchHistory({start=null, end=null, unit=null, step=null, limit=n
         if (world_id) params.set('world_id', world_id);
         if (location_id) params.set('location_id', location_id);
         if (is_f2p !== null && is_f2p !== "") params.set('is_f2p', is_f2p);
+        if (activity_id) params.set('activity_id', activity_id);
 
         const response = await fetch(`${API_BASE}/api/history?${params.toString()}`);
         const contentType = response.headers.get('content-type') || '';
@@ -136,7 +145,7 @@ async function fetchHistory({start=null, end=null, unit=null, step=null, limit=n
 
 // Fetch every series of a comparison in one request. Returns an array of
 // {key, data:[{x,y}]}, dropping series with no points in the range.
-async function fetchGroupedHistory({group_by, start=null, end=null, unit=null, step=null, agg=null, world_id=null, location_id=null, is_f2p=null} = {}) {
+async function fetchGroupedHistory({group_by, start=null, end=null, unit=null, step=null, agg=null, world_id=null, location_id=null, is_f2p=null, activity_id=null} = {}) {
     const params = new URLSearchParams();
     params.set('group_by', group_by);
     if (start) params.set('start', start);
@@ -147,6 +156,7 @@ async function fetchGroupedHistory({group_by, start=null, end=null, unit=null, s
     if (world_id) params.set('world_id', world_id);
     if (location_id) params.set('location_id', location_id);
     if (is_f2p !== null && is_f2p !== "") params.set('is_f2p', is_f2p);
+    if (activity_id) params.set('activity_id', activity_id);
 
     const response = await fetch(`${API_BASE}/api/history/grouped?${params.toString()}`);
     if (!response.ok) {
@@ -312,7 +322,7 @@ function showChartError(msg) {
 }
 
 function setControlsEnabled(enabled) {
-    const ids = ['applyRangeBtn','resetZoomBtn','granularitySelect','aggregationSelect','startInput','endInput','presetSelect', 'worldSelect', 'locationSelect', 'f2pSelect', 'compareSelect'];
+    const ids = ['applyRangeBtn','resetZoomBtn','granularitySelect','aggregationSelect','startInput','endInput','presetSelect', 'worldSelect', 'locationSelect', 'f2pSelect', 'activitySelect', 'compareSelect'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) el.disabled = !enabled;
@@ -363,6 +373,17 @@ function updateGranularityAvailability() {
     }
 }
 
+// Why a selection came back with nothing. Seasonal activities are the common
+// case: Leagues and the Deadman tiers ran for a while and then stopped, so they
+// are empty under the default 7d range even though the history is there.
+function emptyResultMessage(activityId) {
+    if (activityId) {
+        return 'No data for this activity in the selected range. Seasonal activities ' +
+               'run only for a period — try a wider range to find when it was live.';
+    }
+    return 'No data in the selected range.';
+}
+
 // Update chart using inputs (gracefully handle 400 responses from server)
 async function updateFromInputs() {
     const gran = document.getElementById('granularitySelect').value;
@@ -373,6 +394,7 @@ async function updateFromInputs() {
     const worldId = document.getElementById('worldSelect').value;
     const locationId = document.getElementById('locationSelect').value;
     const isF2p = document.getElementById('f2pSelect').value;
+    const activityId = document.getElementById('activitySelect').value;
     const compareMode = document.getElementById('compareSelect').value;
 
     const startISO = startVal ? new Date(startVal).toISOString() : null;
@@ -404,9 +426,10 @@ async function updateFromInputs() {
                 agg: agg,
                 world_id: worldId,
                 location_id: locationId,
-                is_f2p: isF2p
+                is_f2p: isF2p,
+                activity_id: activityId
             });
-            
+
             datasets = [{
                 label: 'Online Players',
                 data: history.map(p => ({ x: new Date(p.timestamp), y: p.count })),
@@ -419,8 +442,8 @@ async function updateFromInputs() {
             // We keep world/location filters if set.
             
             const [f2pData, memData] = await Promise.all([
-                fetchHistory({ start: startISO, end: endISO, unit, step, agg, world_id: worldId, location_id: locationId, is_f2p: 1 }),
-                fetchHistory({ start: startISO, end: endISO, unit, step, agg, world_id: worldId, location_id: locationId, is_f2p: 0 })
+                fetchHistory({ start: startISO, end: endISO, unit, step, agg, world_id: worldId, location_id: locationId, activity_id: activityId, is_f2p: 1 }),
+                fetchHistory({ start: startISO, end: endISO, unit, step, agg, world_id: worldId, location_id: locationId, activity_id: activityId, is_f2p: 0 })
             ]);
 
             datasets = [
@@ -445,7 +468,7 @@ async function updateFromInputs() {
             const series = await fetchGroupedHistory({
                 group_by: 'location',
                 start: startISO, end: endISO, unit, step, agg,
-                world_id: worldId, is_f2p: isF2p
+                world_id: worldId, is_f2p: isF2p, activity_id: activityId
             });
 
             datasets = series.map((s, idx) => ({
@@ -462,7 +485,8 @@ async function updateFromInputs() {
                 group_by: 'world',
                 start: startISO, end: endISO, unit, step, agg,
                 location_id: locationId,
-                is_f2p: isF2p
+                is_f2p: isF2p,
+                activity_id: activityId
             });
 
             datasets = series.map((s, idx) => ({
@@ -475,6 +499,9 @@ async function updateFromInputs() {
             }));
         }
 
+        if (datasets.every(ds => !ds.data || ds.data.length === 0)) {
+            showChartError(emptyResultMessage(activityId));
+        }
         buildChart(datasets, { unit, step });
     } catch (err) {
         console.error('Update failed:', err);
@@ -551,6 +578,9 @@ async function initializePage() {
         if (this.value) {
             document.getElementById('locationSelect').value = "";
             document.getElementById('f2pSelect').value = "";
+            // A single world has exactly one activity, so combining the two
+            // yields either that world or nothing.
+            document.getElementById('activitySelect').value = "";
             document.getElementById('compareSelect').value = "none";
         }
         updateFromInputs();
@@ -558,6 +588,7 @@ async function initializePage() {
 
     document.getElementById('locationSelect').addEventListener('change', updateFromInputs);
     document.getElementById('f2pSelect').addEventListener('change', updateFromInputs);
+    document.getElementById('activitySelect').addEventListener('change', updateFromInputs);
     document.getElementById('compareSelect').addEventListener('change', updateFromInputs);
     document.getElementById('resetZoomBtn').addEventListener('click', () => { if (populationChart) populationChart.resetZoom(); });
     

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -179,6 +179,12 @@ async function fetchGroupedHistory({group_by, start=null, end=null, unit=null, s
     })).filter(s => s.data.length > 0);
 }
 
+// The range boxes no longer describe what is on screen.
+function markRangeCustom() {
+    const presetEl = document.getElementById('presetSelect');
+    if (presetEl) presetEl.value = 'custom';
+}
+
 function buildChart(datasets, granularityInfo) {
     const ctx = document.getElementById('populationChart').getContext('2d');
     const viewerTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Local';
@@ -231,8 +237,15 @@ function buildChart(datasets, granularityInfo) {
             plugins: {
                 decimation: { enabled: true, algorithm: 'lttb', samples: 1000 },
                 zoom: {
-                    pan: { enabled: true, mode: 'x' },
-                    zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
+                    // Zooming and panning move the view without touching the
+                    // range boxes. Marking the preset Custom keeps the dropdown
+                    // honest, and means picking a preset afterwards is a real
+                    // change event rather than a silent no-op.
+                    pan: { enabled: true, mode: 'x', onPanComplete: markRangeCustom },
+                    zoom: {
+                        wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x',
+                        onZoomComplete: markRangeCustom
+                    }
                 },
                 annotation: {
                     annotations: peak ? {
@@ -590,8 +603,18 @@ async function initializePage() {
     // Ensure minute options availability reflects the default range
     updateGranularityAvailability();
 
-    // Wire up controls
-    document.getElementById('applyRangeBtn').addEventListener('click', updateFromInputs);
+    // Wire up controls. Apply recomputes the active preset rather than replaying
+    // the boxes: a preset means "last N from now", and picking the preset that is
+    // already showing fires no change event, so this is the only way to refresh
+    // one. Hand-edited boxes read as Custom and are used as-is.
+    document.getElementById('applyRangeBtn').addEventListener('click', () => {
+        const preset = document.getElementById('presetSelect');
+        if (preset && preset.value && preset.value !== 'custom') {
+            applyPreset(preset.value);
+        } else {
+            updateFromInputs();
+        }
+    });
     const presetEl = document.getElementById('presetSelect');
     if (presetEl) {
         // set default preset to Last 7d

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -290,10 +290,16 @@ function buildChart(datasets, granularityInfo) {
                             month: 'MMM yyyy'
                         }
                     },
+                    // Pin the axis to the range that was asked for. Without this
+                    // Chart.js fits the axis to whatever came back, so a series
+                    // that only covers part of the range stretches to fill it and
+                    // the empty stretches either side vanish.
+                    min: granularityInfo && granularityInfo.min ? granularityInfo.min : undefined,
+                    max: granularityInfo && granularityInfo.max ? granularityInfo.max : undefined,
                     grid: { color: '#4e453a' },
                     ticks: { color: '#d4d4d4', font: { family: 'RuneScape' } }
                 },
-                y: { 
+                y: {
                     beginAtZero: true, 
                     grid: { color: '#4e453a' },
                     ticks: { color: '#d4d4d4', font: { family: 'RuneScape' } }
@@ -371,6 +377,20 @@ function updateGranularityAvailability() {
         Array.from(select.options).forEach(opt => { if (opt.value.endsWith('m')) opt.disabled = false; });
             // Tooltip text is static and does not change
     }
+}
+
+// Per-world tracking started long after the site's history does. Anything before
+// it is the imported weekly series, which is one site-wide number with no
+// world/region/type/activity breakdown, so every filter silently starts there
+// instead of where the range asked. Without this the chart looks broken.
+function filteredRangeNotice(startISO) {
+    const floor = globalMetadata.world_data_start;
+    if (!floor || !startISO || startISO >= floor) return '';
+    const shown = new Date(floor).toLocaleDateString([], {
+        year: 'numeric', month: 'short', day: 'numeric'
+    });
+    return `Filtered history begins ${shown}, when per-world tracking started. ` +
+           'Earlier data on this site is a site-wide total only.';
 }
 
 // Why a selection came back with nothing. Seasonal activities are the common
@@ -499,10 +519,20 @@ async function updateFromInputs() {
             }));
         }
 
+        // Every comparison mode reads world_data too, so they hit the same floor
+        // even with no filter set.
+        const filtered = worldId || locationId || isF2p !== "" || activityId
+                         || compareMode !== 'none';
         if (datasets.every(ds => !ds.data || ds.data.length === 0)) {
             showChartError(emptyResultMessage(activityId));
+        } else if (filtered) {
+            showChartError(filteredRangeNotice(startISO));
         }
-        buildChart(datasets, { unit, step });
+        buildChart(datasets, {
+            unit, step,
+            min: startISO ? new Date(startISO).getTime() : null,
+            max: endISO ? new Date(endISO).getTime() : null
+        });
     } catch (err) {
         console.error('Update failed:', err);
         showChartError(err.message || 'Failed to load data');

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,6 +124,11 @@
                         <option value="0">Members</option>
                     </select>
                 </label>
+                <label style="font-size:0.9em; color:#bdbdbd;">Activity:
+                    <select id="activitySelect">
+                        <option value="">All Activities</option>
+                    </select>
+                </label>
                 <label style="font-size:0.9em; color:#bdbdbd; border-left: 1px solid #5b4a3c; padding-left: 12px; margin-left: 4px;">Compare:
                     <select id="compareSelect" style="background:#383023; border-color:#ff981f;">
                         <option value="none">None</option>

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,98 @@
+"""Grouping of the SLU activity strings.
+
+The cases here are the real descriptions from the production database, including
+the two Jagex whitespace typos, because the point of the module is to survive
+exactly the strings Jagex actually publishes.
+"""
+import unittest
+
+from activities import group_activities
+
+
+def names(entries):
+    return [entry['name'] for entry in entries]
+
+
+def ids_for(entries, name):
+    return next(entry['ids'] for entry in entries if entry['name'] == name)
+
+
+class GroupActivitiesTest(unittest.TestCase):
+
+    def test_no_activity_bucket_is_dropped(self):
+        self.assertEqual(group_activities([(5, '-')]), [])
+
+    def test_family_collapses_to_the_prefix(self):
+        entries = group_activities([
+            (66, 'Castle Wars 1'), (31, 'Castle Wars 2'), (7, 'Castle Wars - Free'),
+        ])
+        self.assertEqual(entries, [{'name': 'Castle Wars', 'ids': [7, 31, 66]}])
+
+    def test_ungrouped_activity_keeps_its_own_name(self):
+        entries = group_activities([(49, 'Guardians of the Rift'), (25, 'Wintertodt')])
+        self.assertEqual(names(entries), ['Guardians of the Rift', 'Wintertodt'])
+
+    def test_a_family_of_one_keeps_the_full_description(self):
+        # 'Trade' is a real prefix, but with a single member the specific name
+        # says more than the prefix does.
+        entries = group_activities([(6, 'Trade - Free')])
+        self.assertEqual(names(entries), ['Trade - Free'])
+
+    def test_longest_prefix_wins(self):
+        entries = group_activities([
+            (17, 'Deadman'), (76, 'Deadman - 3-60'), (72, 'Deadman - Permanent'),
+            (78, 'Deadman Finale - 45-60'), (80, 'Deadman Finale - 96+'),
+        ])
+        self.assertEqual(names(entries), ['Deadman', 'Deadman Finale'])
+        self.assertEqual(ids_for(entries, 'Deadman'), [17, 72, 76])
+        self.assertEqual(ids_for(entries, 'Deadman Finale'), [78, 80])
+
+    def test_a_prefix_must_be_at_the_start(self):
+        # 'Event PvP World' contains 'PvP World' but is a different activity.
+        entries = group_activities([
+            (65, 'PvP World'), (10, 'PvP World - Free'), (14, 'Event PvP World'),
+        ])
+        self.assertEqual(names(entries), ['Event PvP World', 'PvP World'])
+        self.assertEqual(ids_for(entries, 'PvP World'), [10, 65])
+
+    def test_a_prefix_must_end_on_a_separator(self):
+        # Guards against a future 'Trader'-style name joining 'Trade'.
+        entries = group_activities([(6, 'Trade - Free'), (68, 'Trade - Members'),
+                                    (900, 'Traders Guild')])
+        self.assertEqual(names(entries), ['Trade', 'Traders Guild'])
+
+    def test_whitespace_typos_land_in_the_same_group(self):
+        entries = group_activities([
+            (83, 'Leagues VI'),
+            (92, 'Leagues VI - The Hueycoatl'),
+            (93, 'Leagues VI -  The Hueycoatl'),   # double space, as published
+            (96, 'Leagues VI -Barbarian Assault'),  # missing space, as published
+        ])
+        self.assertEqual(entries, [{'name': 'Leagues VI', 'ids': [83, 92, 93, 96]}])
+
+    def test_no_separator_still_groups(self):
+        entries = group_activities([(28, 'Brimhaven Agility'),
+                                    (45, 'Brimhaven Agility Arena')])
+        self.assertEqual(entries, [{'name': 'Brimhaven Agility', 'ids': [28, 45]}])
+
+    def test_parenthesised_variants_group(self):
+        entries = group_activities([
+            (69, 'PvP Arena (AUS)'), (64, 'PvP Arena (UK)'), (16, 'PvP Arena (US)'),
+        ])
+        self.assertEqual(entries, [{'name': 'PvP Arena', 'ids': [16, 64, 69]}])
+
+    def test_skill_totals_stay_separate(self):
+        # A numeric prefix, deliberately not a family: the thresholds are the
+        # interesting part and summing them would mix unlike populations.
+        entries = group_activities([(22, '1250 skill total'), (35, '2200 skill total')])
+        self.assertEqual(names(entries), ['1250 skill total', '2200 skill total'])
+
+    def test_entries_are_sorted_case_insensitively(self):
+        entries = group_activities([(1, 'Zalcano'), (2, 'LMS Casual'),
+                                    (3, 'LMS Competitive'), (4, 'Leagues VI'),
+                                    (5, 'Leagues VI - CoX')])
+        self.assertEqual(names(entries), ['Leagues VI', 'LMS', 'Zalcano'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,12 +26,21 @@ SCRAPE_TIMES = [
     '2026-01-06T00:00:00Z',
 ]
 
-# world -> (location_id, is_f2p, player counts across the 6 scrapes)
+# Two of these are one family, so a group selection sends both ids and has to
+# sum them; `-` stays the no-activity bucket.
+ACTIVITIES = {
+    1: '-',
+    2: 'Castle Wars 1',
+    3: 'Castle Wars - Free',
+    4: 'Guardians of the Rift',
+}
+
+# world -> (location_id, is_f2p, activity_id, player counts across the 6 scrapes)
 WORLDS = {
-    301: (1, 0, [100, 110, 120, 130, 140, 150]),
-    302: (1, 1, [10, 20, 30, 40, 50, 60]),
-    303: (2, 0, [200, 210, 220, 230, 240, 250]),
-    304: (2, 1, [5, 5, 5, 5, 5, 5]),
+    301: (1, 0, 2, [100, 110, 120, 130, 140, 150]),
+    302: (1, 1, 3, [10, 20, 30, 40, 50, 60]),
+    303: (2, 0, 4, [200, 210, 220, 230, 240, 250]),
+    304: (2, 1, 1, [5, 5, 5, 5, 5, 5]),
 }
 
 # Global `players` samples — deliberately NOT the sum of the world counts, so a
@@ -59,25 +68,27 @@ def build_db(path):
 
     conn.executemany('INSERT INTO locations (id, name) VALUES (?, ?)',
                      [(1, 'United States'), (2, 'Germany')])
-    conn.execute("INSERT INTO activities (id, description) VALUES (1, '-')")
+    conn.executemany('INSERT INTO activities (id, description) VALUES (?, ?)',
+                     sorted(ACTIVITIES.items()))
 
-    # One world_details row per (location, f2p) pair the worlds actually use.
+    # One world_details row per (location, f2p, activity) triple the worlds use.
     detail_ids = {}
-    for world, (loc, f2p, _) in WORLDS.items():
-        key = (loc, f2p)
+    for world, (loc, f2p, activity, _) in WORLDS.items():
+        key = (loc, f2p, activity)
         if key not in detail_ids:
             cur = conn.execute(
-                'INSERT INTO world_details (location_id, is_f2p, activity_id) VALUES (?, ?, 1)', key)
+                'INSERT INTO world_details (location_id, is_f2p, activity_id) '
+                'VALUES (?, ?, ?)', key)
             detail_ids[key] = cur.lastrowid
 
     for i, ts in enumerate(SCRAPE_TIMES, start=1):
         conn.execute('INSERT INTO scrape_events (id, timestamp) VALUES (?, ?)', (i, ts))
         conn.execute('INSERT INTO players (timestamp, count) VALUES (?, ?)',
                      (ts, PLAYER_COUNTS[i - 1]))
-        for world, (loc, f2p, counts) in WORLDS.items():
+        for world, (loc, f2p, activity, counts) in WORLDS.items():
             conn.execute(
                 'INSERT INTO world_data (scrape_id, world_number, player_count, detail_id) '
-                'VALUES (?, ?, ?, ?)', (i, world, counts[i - 1], detail_ids[(loc, f2p)]))
+                'VALUES (?, ?, ?, ?)', (i, world, counts[i - 1], detail_ids[(loc, f2p, activity)]))
 
     conn.commit()
     conn.close()
@@ -217,7 +228,7 @@ class HistoryWorldDataTest(ApiTestCase):
     def test_single_world_returns_its_own_counts(self):
         _, body = self.get(
             '/api/history?world_id=301&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
-        self.assertEqual([r['count'] for r in body], WORLDS[301][2])
+        self.assertEqual([r['count'] for r in body], WORLDS[301][3])
 
     def test_location_sums_within_each_scrape(self):
         _, body = self.get(
@@ -234,7 +245,7 @@ class HistoryWorldDataTest(ApiTestCase):
     def test_location_and_f2p_combine(self):
         _, body = self.get(
             '/api/history?location_id=2&is_f2p=0&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
-        self.assertEqual([r['count'] for r in body], WORLDS[303][2])
+        self.assertEqual([r['count'] for r in body], WORLDS[303][3])
 
     def test_bucketing_aggregates_across_time_not_within_it(self):
         # Hourly max of a summed series: the sum happens per scrape first, then
@@ -249,6 +260,50 @@ class HistoryWorldDataTest(ApiTestCase):
             '/api/history?world_id=301&start=2020-01-01T00:00:00Z&end=2020-01-02T00:00:00Z')
         self.assertEqual(status, 200)
         self.assertEqual(body, [])
+
+    def test_single_activity_sums_only_its_worlds(self):
+        _, body = self.get(
+            '/api/history?activity_id=4&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], WORLDS[303][3])
+
+    def test_grouped_activity_sums_every_member(self):
+        # The Castle Wars family: worlds 301 + 302, sent as one comma-separated
+        # value the way the dropdown does it.
+        _, body = self.get(
+            '/api/history?activity_id=2,3&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], [110, 130, 150, 170, 190, 210])
+
+    def test_repeated_activity_id_params_are_equivalent_to_a_list(self):
+        _, body = self.get(
+            '/api/history?activity_id=2&activity_id=3'
+            '&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], [110, 130, 150, 170, 190, 210])
+
+    def test_activity_and_f2p_combine(self):
+        # Castle Wars is two worlds, only one of which is F2P.
+        _, body = self.get(
+            '/api/history?activity_id=2,3&is_f2p=1'
+            '&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], WORLDS[302][3])
+
+    def test_unmatched_activity_is_empty_not_an_error(self):
+        # What a retired seasonal activity looks like: a valid id, no rows.
+        status, body = self.get(
+            '/api/history?activity_id=999&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual(status, 200)
+        self.assertEqual(body, [])
+
+    def test_unparseable_activity_id_drops_the_filter(self):
+        # Matches how `type=int` treats location_id: a bad value is no filter.
+        _, body = self.get(
+            '/api/history?activity_id=abc&start=2026-01-05T00:00:00Z&end=2026-01-06T00:00:00Z')
+        self.assertEqual([r['count'] for r in body], PLAYER_COUNTS)
+
+    def test_too_many_activity_ids_is_rejected(self):
+        ids = ','.join(str(n) for n in range(500))
+        status, body = self.get(f'/api/history?activity_id={ids}')
+        self.assertEqual(status, 400)
+        self.assertIn('activity_id', body['error'])
 
 
 class HistoryGroupedTest(ApiTestCase):
@@ -303,6 +358,27 @@ class HistoryGroupedTest(ApiTestCase):
             f'/api/history/grouped?group_by=world&unit=hour&is_f2p=1&{self.RANGE}')
         self.assertEqual([s['key'] for s in body['series']], [302, 304])
 
+    def test_activity_filter_narrows_the_series_set(self):
+        _, body = self.get(
+            f'/api/history/grouped?group_by=world&unit=hour&activity_id=2,3&{self.RANGE}')
+        self.assertEqual([s['key'] for s in body['series']], [301, 302])
+
+    def test_activity_filter_applies_to_a_summed_grouping(self):
+        # group_by=location already joins world_details; the activity clause has
+        # to land on that same join rather than a second one.
+        _, body = self.get(
+            f'/api/history/grouped?group_by=location&unit=hour&activity_id=2,3&{self.RANGE}')
+        by_key = {s['key']: s['counts'] for s in body['series']}
+        self.assertEqual(list(by_key), [1])
+        self.assertEqual(by_key[1], [150, 190])
+
+    def test_too_many_activity_ids_is_rejected(self):
+        ids = ','.join(str(n) for n in range(500))
+        status, body = self.get(
+            f'/api/history/grouped?group_by=world&unit=hour&activity_id={ids}&{self.RANGE}')
+        self.assertEqual(status, 400)
+        self.assertIn('activity_id', body['error'])
+
     def test_range_outside_all_scrapes_is_empty(self):
         status, body = self.get(
             '/api/history/grouped?group_by=world&unit=hour'
@@ -328,6 +404,18 @@ class MetadataTest(ApiTestCase):
         self.assertEqual(sorted(loc['name'] for loc in body['locations']),
                          ['Germany', 'United States'])
         self.assertEqual(sorted(body['worlds']), [301, 302, 303, 304])
+
+    def test_activities_stay_raw(self):
+        _, body = self.get('/api/metadata')
+        self.assertEqual(sorted(a['description'] for a in body['activities']),
+                         sorted(ACTIVITIES.values()))
+
+    def test_activity_groups_collapse_families_and_drop_no_activity(self):
+        _, body = self.get('/api/metadata')
+        self.assertEqual(body['activity_groups'], [
+            {'name': 'Castle Wars', 'ids': [2, 3]},
+            {'name': 'Guardians of the Rift', 'ids': [4]},
+        ])
 
 
 if __name__ == '__main__':

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -405,6 +405,11 @@ class MetadataTest(ApiTestCase):
                          ['Germany', 'United States'])
         self.assertEqual(sorted(body['worlds']), [301, 302, 303, 304])
 
+    def test_world_data_start_is_the_first_scrape(self):
+        # The floor the UI warns about: filtered queries cannot reach earlier.
+        _, body = self.get('/api/metadata')
+        self.assertEqual(body['world_data_start'], SCRAPE_TIMES[0])
+
     def test_activities_stay_raw(self):
         _, body = self.get('/api/metadata')
         self.assertEqual(sorted(a['description'] for a in body['activities']),


### PR DESCRIPTION
Adds an Activity filter alongside World / Region / Type, plus two chart fixes found while testing it.

## Activity filter

Jagex publishes activities as free text, so one real activity arrives under several names —
`Castle Wars 1`, `Castle Wars 2`, `Castle Wars - Free`. New `activities.py` collapses these for
display only: 99 activities become 62 dropdown entries. The database and the data dump keep every
string exactly as scraped.

Grouping is a curated prefix list matched longest-first, not inferred. Inference breaks on the cases
that matter: `Brimhaven Agility Arena` has no separator, the skill totals are numeric-prefixed, and
`Event PvP World` must not fall into `PvP World`. A new activity defaults to showing as itself.

`activity_id` accepts a set (comma-separated or repeated), so one grouped entry sends every member
id and the query layer needs no concept of a group. Capped at 200 ids. `/api/metadata` gains
`activity_groups` next to the untouched raw `activities`.

Worth knowing: `Deadman` sums six retired tiers with the one live `- Permanent` world, so the line
steps down ~95% partway through. That is what the data says, and it is deliberate.

## Chart fixes

**Filtered charts misrepresented their range.** Chart.js was auto-fitting the x-axis to whatever came
back, so Leagues VI over a one-year range drew its 58 real days stretched across the full width — it
looked like the league ran all year. The axis is now pinned to the requested range, so gaps are
visible. Affected any series with gaps, not just activities.

Related: per-world tracking only starts 2025-12-04. Earlier history is the imported weekly series, a
site-wide total with no breakdown, so *every* filter silently floors there. `/api/metadata` now
returns `world_data_start` and the chart says so instead of looking broken.

**Range presets desynced from the view.** Zooming or panning changed the chart without touching the
range boxes, leaving the dropdown claiming "Last 7d". Re-picking that preset fired no `change` event,
so nothing happened. Zoom and pan now mark the range Custom, and Apply recomputes the active preset
rather than replaying stale absolute datetimes.

## Testing

83 tests, flake8 clean. New `tests/test_activities.py` covers grouping using the real production
strings, including the two Jagex whitespace typos (`Leagues VI -  The Hueycoatl`,
`Leagues VI -Barbarian Assault`). API tests cover single and grouped activity filters on both
endpoints. Verified against the live 116 MB database: every activity lands in exactly one entry.
