### PR TITLE
Replace the All Worlds compare with a picker for specific worlds and activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A comprehensive tool to track, store, and visualize Old School RuneScape (OSRS) 
 *   **Interactive Dashboard**:
     *   Real-time player count display.
     *   Historical graphs with zoom and pan capabilities.
-    *   **Advanced Filtering**: Filter history by World, Region (Location), or World Type (F2P/Members).
-    *   **Comparison Mode**: Compare F2P vs Members, or compare different Regions side-by-side.
+    *   **Advanced Filtering**: Filter history by World, Region (Location), World Type (F2P/Members), or Activity.
+    *   **Comparison Mode**: Compare F2P vs Members, compare Regions side-by-side, or pick up to 8 specific worlds and activities to plot together.
 
 ## Requirements
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -186,6 +186,120 @@ label[style*="color:#bdbdbd"] {
 .info:hover .tooltip {
     display: block;
 }
+/* Series picker (Compare -> "Pick series…") */
+.picker {
+    margin-bottom: 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #383023;
+}
+.picker-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+}
+#seriesSearch {
+    min-width: 260px;
+}
+.picker-count {
+    color: #d4d4d4;
+    font-size: 0.85em;
+    text-shadow: 1px 1px 0 #000;
+}
+/* Zero-height anchor so the results list overlays the chart instead of
+   pushing it down every keystroke. */
+.picker-anchor {
+    position: relative;
+    width: 100%;
+    height: 0;
+}
+.picker-results {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 4px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    width: min(360px, 90vw);
+    max-height: 40vh;
+    overflow-y: auto;
+    background: #2b231a;
+    border: 2px solid #383023;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.5);
+    z-index: 40;
+    text-align: left;
+}
+.picker-results li {
+    padding: 5px 8px;
+    color: #ffff00;
+    font-size: 0.9em;
+    cursor: pointer;
+    text-shadow: 1px 1px 0 #000;
+}
+.picker-results li.active,
+.picker-results li:hover {
+    background: #5b4a3c;
+    color: #ffffff;
+}
+.picker-results li.picker-note {
+    color: #d4d4d4;
+    cursor: default;
+    font-size: 0.85em;
+}
+.picker-results li.picker-note:hover {
+    background: none;
+    color: #d4d4d4;
+}
+.picker-kind {
+    color: #ff981f;
+    font-size: 0.8em;
+    margin-left: 6px;
+}
+.picker-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+    margin-top: 8px;
+}
+.picker-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #2b231a;
+    border: 1px solid #5b4a3c;
+    padding: 2px 6px;
+    font-size: 0.85em;
+    color: #ffff00;
+    text-shadow: 1px 1px 0 #000;
+}
+/* Matches the line colour this series is plotted in. */
+.picker-swatch {
+    width: 10px;
+    height: 10px;
+    border: 1px solid #000;
+    flex: none;
+}
+.picker-chip button {
+    background: none;
+    border: none;
+    padding: 0 2px;
+    font-size: 1em;
+    line-height: 1;
+    color: #d4d4d4;
+    cursor: pointer;
+}
+.picker-chip button:hover {
+    background: none;
+    color: #ff0000;
+}
+/* A filter that the active compare mode supersedes. */
+.control-muted {
+    opacity: 0.45;
+}
+
 /* Easter Egg: Connection Lost */
 #connection-lost {
     display: none;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -18,6 +18,16 @@ let populationChart = null;
 let rawHistory = []; // cache of last fetched raw points
 let globalMetadata = { locations: [], worlds: [], activity_groups: [] }; // Store metadata for comparison logic
 
+// Line colours, in the order series are plotted. The picker caps selections at
+// this length so no two hand-picked series ever share a colour.
+const SERIES_COLORS = ['#ffff00', '#00ff00', '#00ffff', '#ff00ff', '#ff981f', '#ff0000', '#ffffff', '#aaaaaa'];
+const MAX_SERIES = SERIES_COLORS.length;
+
+// Each hand-picked series is its own /api/history call, and each of those is a
+// world_data scan. Firing eight at once would occupy eight PythonAnywhere
+// workers simultaneously; a pool keeps the total work the same but the site up.
+const SERIES_CONCURRENCY = 3;
+
 // Utility: format JS Date -> ISO used by datetime-local (without seconds)
 function toLocalInputISO(date) {
     const pad = n => String(n).padStart(2, '0');
@@ -58,9 +68,260 @@ async function fetchMetadata() {
             opt.textContent = group.name;
             activitySelect.appendChild(opt);
         });
+
+        seriesCatalog = buildSeriesCatalog(data);
+        renderSeriesResults();
     } catch (error) {
         console.error('Error fetching metadata:', error);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Series picker
+//
+// A hand-picked comparison is 2-8 series, and each one is an ordinary
+// /api/history call with a filter the endpoint already supports: a world is
+// world_id, an activity group is its member ids (activity_id takes a set). So
+// this is entirely frontend — no new endpoint, and going through /api/history
+// per selection keeps the display groups intact, which a server-side grouping
+// would split back into raw activity strings.
+// ---------------------------------------------------------------------------
+
+let seriesCatalog = [];   // everything selectable
+let selectedSeries = [];  // what is plotted, in colour order
+let resultsCursor = -1;   // keyboard highlight within the visible results
+
+// Enough to scroll through, few enough that 447 worlds don't build 447 nodes.
+const MAX_RESULTS = 40;
+
+function buildSeriesCatalog(data) {
+    const worlds = (data.worlds || []).map(w => ({
+        key: `w:${w}`,
+        kind: 'world',
+        label: `World ${parseInt(w) + 300}`,
+        params: { world_id: w }
+    }));
+    // Keyed by name, not by ids: the ids are autoincrement surrogates, and a
+    // group's membership shifts when Jagex adds a sibling activity.
+    const activities = (data.activity_groups || []).map(group => ({
+        key: `a:${group.name}`,
+        kind: 'activity',
+        label: group.name,
+        params: { activity_id: group.ids.join(',') }
+    }));
+    return worlds.concat(activities);
+}
+
+function matchingSeries(query) {
+    const q = query.trim().toLowerCase();
+    const chosen = new Set(selectedSeries.map(s => s.key));
+    return seriesCatalog.filter(item =>
+        !chosen.has(item.key) && (!q || item.label.toLowerCase().includes(q)));
+}
+
+function renderSeriesResults() {
+    const input = document.getElementById('seriesSearch');
+    const list = document.getElementById('seriesResults');
+    if (!input || !list) return;
+
+    const open = document.activeElement === input && !input.disabled;
+    list.innerHTML = '';
+    if (!open) {
+        list.style.display = 'none';
+        input.setAttribute('aria-expanded', 'false');
+        return;
+    }
+
+    if (selectedSeries.length >= MAX_SERIES) {
+        list.appendChild(noteItem(`Limit of ${MAX_SERIES} series reached — remove one to add another.`));
+    } else {
+        const matches = matchingSeries(input.value);
+        if (matches.length === 0) {
+            list.appendChild(noteItem('Nothing matches.'));
+        }
+        matches.slice(0, MAX_RESULTS).forEach((item, idx) => {
+            const li = document.createElement('li');
+            li.setAttribute('role', 'option');
+            li.textContent = item.label;
+            const kind = document.createElement('span');
+            kind.className = 'picker-kind';
+            kind.textContent = item.kind === 'world' ? 'world' : 'activity';
+            li.appendChild(kind);
+            if (idx === resultsCursor) {
+                li.classList.add('active');
+                li.setAttribute('aria-selected', 'true');
+            }
+            // mousedown, not click: the input's blur would tear the list down first.
+            li.addEventListener('mousedown', ev => {
+                ev.preventDefault();
+                addSeries(item);
+            });
+            list.appendChild(li);
+        });
+        if (matches.length > MAX_RESULTS) {
+            list.appendChild(noteItem(`…and ${matches.length - MAX_RESULTS} more — keep typing.`));
+        }
+    }
+
+    list.style.display = 'block';
+    input.setAttribute('aria-expanded', 'true');
+}
+
+function noteItem(text) {
+    const li = document.createElement('li');
+    li.className = 'picker-note';
+    li.textContent = text;
+    return li;
+}
+
+function renderSeriesChips() {
+    const chips = document.getElementById('seriesChips');
+    const count = document.getElementById('seriesCount');
+    if (!chips) return;
+
+    chips.innerHTML = '';
+    selectedSeries.forEach((item, idx) => {
+        const chip = document.createElement('span');
+        chip.className = 'picker-chip';
+
+        const swatch = document.createElement('span');
+        swatch.className = 'picker-swatch';
+        swatch.style.background = SERIES_COLORS[idx];
+        chip.appendChild(swatch);
+        chip.appendChild(document.createTextNode(item.label));
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.textContent = '×';
+        remove.setAttribute('aria-label', `Remove ${item.label}`);
+        remove.addEventListener('click', () => removeSeries(item.key));
+        chip.appendChild(remove);
+
+        chips.appendChild(chip);
+    });
+
+    if (count) {
+        count.textContent = selectedSeries.length
+            ? `${selectedSeries.length} of ${MAX_SERIES} selected`
+            : `none selected (up to ${MAX_SERIES})`;
+    }
+}
+
+function addSeries(item) {
+    if (selectedSeries.length >= MAX_SERIES) return;
+    if (selectedSeries.some(s => s.key === item.key)) return;
+    selectedSeries.push(item);
+
+    const input = document.getElementById('seriesSearch');
+    if (input) input.value = '';
+    resultsCursor = 0;
+    renderSeriesChips();
+    renderSeriesResults();
+    updateFromInputs();
+}
+
+function removeSeries(key) {
+    selectedSeries = selectedSeries.filter(s => s.key !== key);
+    renderSeriesChips();
+    renderSeriesResults();
+    updateFromInputs();
+}
+
+function onSearchKeydown(ev) {
+    const visible = Math.min(matchingSeries(ev.target.value).length, MAX_RESULTS);
+    if (ev.key === 'ArrowDown' || ev.key === 'ArrowUp') {
+        ev.preventDefault();
+        if (visible === 0) return;
+        const delta = ev.key === 'ArrowDown' ? 1 : -1;
+        resultsCursor = (resultsCursor + delta + visible) % visible;
+        renderSeriesResults();
+        const active = document.querySelector('#seriesResults li.active');
+        if (active) active.scrollIntoView({ block: 'nearest' });
+    } else if (ev.key === 'Enter') {
+        ev.preventDefault();
+        const matches = matchingSeries(ev.target.value);
+        const pick = matches[resultsCursor >= 0 ? resultsCursor : 0];
+        if (pick) addSeries(pick);
+    } else if (ev.key === 'Escape') {
+        ev.target.blur();
+    }
+}
+
+// Custom compare supersedes the four filter dropdowns: each series carries its
+// own filter, and applying a global one on top would silently empty any series
+// it doesn't match (a world has exactly one region, type and activity).
+const SUPERSEDED_FILTERS = ['worldSelect', 'locationSelect', 'f2pSelect', 'activitySelect'];
+
+function syncCompareUI() {
+    const custom = document.getElementById('compareSelect').value === 'custom';
+    const picker = document.getElementById('comparePicker');
+    if (picker) picker.style.display = custom ? 'block' : 'none';
+    SUPERSEDED_FILTERS.forEach(id => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.disabled = custom;
+        if (el.parentElement) el.parentElement.classList.toggle('control-muted', custom);
+    });
+}
+
+// Fetch the selected series through a small pool. Returns one entry per
+// selection, in selection order, with failures carried rather than thrown so a
+// single bad series doesn't take the whole chart down.
+async function fetchSelectedSeries(range) {
+    const results = new Array(selectedSeries.length);
+    let next = 0;
+
+    const worker = async () => {
+        while (next < selectedSeries.length) {
+            const idx = next++;
+            const item = selectedSeries[idx];
+            try {
+                const data = await fetchHistory(Object.assign({}, range, item.params));
+                results[idx] = { item, data };
+            } catch (err) {
+                results[idx] = { item, data: [], error: err.message || 'failed to load' };
+            }
+        }
+    };
+
+    const workers = Math.min(SERIES_CONCURRENCY, selectedSeries.length);
+    await Promise.all(Array.from({ length: workers }, worker));
+    return results;
+}
+
+// A series with no points keeps its legend entry and says why, rather than
+// vanishing — a retired world or a seasonal activity is an answer, not a gap.
+function seriesLabel(result) {
+    const base = result.item.kind === 'activity'
+        ? `${result.item.label} (activity)`
+        : result.item.label;
+    if (result.error) return `${base} — failed to load`;
+    if (result.data.length === 0) return `${base} — no data in range`;
+    return base;
+}
+
+function customDatasets(results) {
+    return results.map((result, idx) => ({
+        label: seriesLabel(result),
+        data: result.data.map(p => ({ x: new Date(p.timestamp), y: p.count })),
+        borderColor: SERIES_COLORS[idx],
+        backgroundColor: null
+    }));
+}
+
+function customNotice(results, startISO) {
+    if (results.length === 0) {
+        return `Search for worlds or activities above — up to ${MAX_SERIES} at a time.`;
+    }
+    const failed = results.filter(r => r.error);
+    if (failed.length) {
+        return `${failed.length} of ${results.length} series failed to load.`;
+    }
+    if (results.every(r => r.data.length === 0)) {
+        return 'None of these series have data in the selected range. Seasonal ' +
+               'activities and retired worlds only cover the period they ran — try a wider range.';
+    }
+    return filteredRangeNotice(startISO);
 }
 
 // Fetch latest player count
@@ -341,11 +602,13 @@ function showChartError(msg) {
 }
 
 function setControlsEnabled(enabled) {
-    const ids = ['applyRangeBtn','resetZoomBtn','granularitySelect','aggregationSelect','startInput','endInput','presetSelect', 'worldSelect', 'locationSelect', 'f2pSelect', 'activitySelect', 'compareSelect'];
+    const ids = ['applyRangeBtn','resetZoomBtn','granularitySelect','aggregationSelect','startInput','endInput','presetSelect', 'worldSelect', 'locationSelect', 'f2pSelect', 'activitySelect', 'compareSelect', 'seriesSearch', 'seriesClearBtn'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) el.disabled = !enabled;
     });
+    // Re-enabling would otherwise hand the superseded filters back.
+    if (enabled) syncCompareUI();
 }
 
 // Simple spinner helpers
@@ -447,7 +710,7 @@ async function updateFromInputs() {
     
     try {
         let datasets = [];
-        const colors = ['#ffff00', '#00ff00', '#00ffff', '#ff00ff', '#ff981f', '#ff0000', '#ffffff', '#aaaaaa'];
+        let customResults = null;
 
         if (compareMode === 'none') {
             // Standard single series fetch
@@ -507,36 +770,25 @@ async function updateFromInputs() {
             datasets = series.map((s, idx) => ({
                 label: locNames.get(String(s.key)) || `Location ${s.key}`,
                 data: s.data,
-                borderColor: colors[idx % colors.length],
+                borderColor: SERIES_COLORS[idx % SERIES_COLORS.length],
                 backgroundColor: null // No fill for many lines to avoid clutter
             }));
-        } else if (compareMode === 'worlds') {
-            // Compare All Worlds (Filtered by other selections)
-            // One request grouped by world server-side. Worlds with no data in the
-            // range (retired ones, or ones the filters exclude) are simply absent.
-            const series = await fetchGroupedHistory({
-                group_by: 'world',
-                start: startISO, end: endISO, unit, step, agg,
-                location_id: locationId,
-                is_f2p: isF2p,
-                activity_id: activityId
+        } else if (compareMode === 'custom') {
+            // Hand-picked series. Each carries its own filter, so the dropdowns
+            // above are ignored — see SUPERSEDED_FILTERS.
+            customResults = await fetchSelectedSeries({
+                start: startISO, end: endISO, unit, step, agg
             });
-
-            datasets = series.map((s, idx) => ({
-                label: `World ${parseInt(s.key) + 300}`,
-                data: s.data,
-                borderColor: colors[idx % colors.length],
-                backgroundColor: null,
-                borderWidth: 1, // Thinner lines for mass comparison
-                pointRadius: 0
-            }));
+            datasets = customDatasets(customResults);
         }
 
         // Every comparison mode reads world_data too, so they hit the same floor
         // even with no filter set.
         const filtered = worldId || locationId || isF2p !== "" || activityId
                          || compareMode !== 'none';
-        if (datasets.every(ds => !ds.data || ds.data.length === 0)) {
+        if (customResults) {
+            showChartError(customNotice(customResults, startISO));
+        } else if (datasets.every(ds => !ds.data || ds.data.length === 0)) {
             showChartError(emptyResultMessage(activityId));
         } else if (filtered) {
             showChartError(filteredRangeNotice(startISO));
@@ -642,7 +894,25 @@ async function initializePage() {
     document.getElementById('locationSelect').addEventListener('change', updateFromInputs);
     document.getElementById('f2pSelect').addEventListener('change', updateFromInputs);
     document.getElementById('activitySelect').addEventListener('change', updateFromInputs);
-    document.getElementById('compareSelect').addEventListener('change', updateFromInputs);
+    document.getElementById('compareSelect').addEventListener('change', () => {
+        syncCompareUI();
+        updateFromInputs();
+    });
+
+    // Series picker
+    const searchEl = document.getElementById('seriesSearch');
+    searchEl.addEventListener('input', () => { resultsCursor = 0; renderSeriesResults(); });
+    searchEl.addEventListener('focus', () => { resultsCursor = 0; renderSeriesResults(); });
+    searchEl.addEventListener('blur', () => renderSeriesResults());
+    searchEl.addEventListener('keydown', onSearchKeydown);
+    document.getElementById('seriesClearBtn').addEventListener('click', () => {
+        if (selectedSeries.length === 0) return;
+        selectedSeries = [];
+        renderSeriesChips();
+        updateFromInputs();
+    });
+    renderSeriesChips();
+    syncCompareUI();
     document.getElementById('resetZoomBtn').addEventListener('click', () => { if (populationChart) populationChart.resetZoom(); });
     
     // Recalculate availability when user edits start/end inputs

--- a/templates/index.html
+++ b/templates/index.html
@@ -134,9 +134,27 @@
                         <option value="none">None</option>
                         <option value="type">F2P vs Members</option>
                         <option value="location">Regions</option>
-                        <option value="worlds">All Worlds</option>
+                        <option value="custom">Pick series…</option>
                     </select>
                 </label>
+            </div>
+
+            <!-- Hand-picked comparison. Hidden until Compare is "Pick series…". -->
+            <div id="comparePicker" class="picker" style="display:none;">
+                <div class="picker-row">
+                    <label style="font-size:0.9em; color:#bdbdbd;">Series:
+                        <input id="seriesSearch" type="text" autocomplete="off" role="combobox"
+                               aria-expanded="false" aria-controls="seriesResults" aria-autocomplete="list"
+                               placeholder="Search worlds and activities…">
+                    </label>
+                    <span id="seriesCount" class="picker-count"></span>
+                    <button id="seriesClearBtn" type="button">Clear</button>
+                </div>
+                <div id="seriesChips" class="picker-chips" aria-live="polite"></div>
+                <!-- Below the chips so the dropdown never hides what is already picked. -->
+                <div class="picker-anchor">
+                    <ul id="seriesResults" class="picker-results" role="listbox" style="display:none;"></ul>
+                </div>
             </div>
 
             <div style="display:flex; flex-wrap:wrap; gap:8px; justify-content:center; align-items:center; margin-bottom:12px;">
@@ -204,7 +222,7 @@
                     <h3 style="color: #ff981f; font-size: 1.1em; margin-bottom: 8px;">About OSRS Player Count Tracker</h3>
                     <div style="margin-top:6px;">This <strong>OSRS player count tracker</strong> displays real-time Old School RuneScape population statistics. Track how many players are online in OSRS right now, view historical player count trends, and analyze population data by world, region, F2P vs Members, and more.</div>
                     <div style="margin-top:8px;"><strong>How it works:</strong> Our automated system checks the official Old School RuneScape homepage every 5 minutes to capture the current player count. This data is stored in a database and displayed through interactive charts, giving you accurate OSRS population statistics updated in real-time.</div>
-                    <div style="margin-top:8px;"><strong>Features:</strong> Filter by specific worlds, compare F2P and Members populations, view regional breakdowns, and explore years of historical OSRS player data with customizable time ranges and granularity options.</div>
+                    <div style="margin-top:8px;"><strong>Features:</strong> Filter by specific worlds, minigames and skill worlds, compare F2P and Members populations, view regional breakdowns, plot any handful of worlds and activities against each other, and explore years of historical OSRS player data with customizable time ranges and granularity options.</div>
                     <div style="margin-top:8px;">Historical data (older than Dec 2, 2025) was sourced from <a href="https://www.misplaceditems.com/rs_tools/graph" target="_blank" rel="noopener noreferrer">misplaceditems.com — RS Tools (graph)</a> as well as <a href="https://playercount.dev/" target="_blank" rel="noopener noreferrer">playercount.dev</a>. That historical dataset is coarser: its timestamps and sample intervals are not as fine-grained as the samples collected by this bot, so recent data (collected by the bot) will appear with higher resolution than the imported history.</div>
                     <div style="margin-top:8px;"><strong>Download the data:</strong> the full database is published as a <a href="https://github.com/UsefulEndymion/osrsplayercount/releases/latest" target="_blank" rel="noopener noreferrer">downloadable snapshot</a>, refreshed periodically. It includes every world-level sample and the complete global history, plus a CSV of just the global player count for anyone who would rather not open a database.</div>
                     <div style="margin-top:8px; color: #ff981f;"><strong>Note:</strong> Detailed world data (including specific world counts, F2P vs Members splits, and regional data) only started being collected on Dec 4, 2025. Any data prior to this date only contains the global player count.</div>


### PR DESCRIPTION
The old "All Worlds" compare plotted every world at once with no way to choose which ones, so it was hard to read and not much use. This replaces it with a picker: search for worlds and activities, add up to 8, and they all get plotted together.

No backend changes. Each pick is a normal /api/history call (world_id, or an activity group's member ids), which also means activity groups stay grouped instead of Castle Wars splitting back into its three separate names.

A few notes on the choices:

* Picks are fetched 3 at a time rather than all at once. The total work is about the same as the old All Worlds mode, but 8 simultaneous requests would tie up 8 PythonAnywhere workers.
* In picker mode the World/Location/Type/Activity dropdowns are greyed out. A world only has one region, type and activity, so applying one of those on top of a picked world empties it rather than narrowing it.
* The limit of 8 is just how many colours are in the palette. Chip colours match the line colours so you can tell which is which.
* A series with no data in the range keeps its legend entry and says so, so seasonal activities and retired worlds do not silently vanish. Same if one fails to load.
* group_by=world is still in the API. It is the grouped endpoint default and the tests cover it, it just has no UI using it any more.

Checked in the browser: all four compare modes, adding and removing picks with both mouse and keyboard, the limit of 8, Clear, and changing the range and granularity with picks active. Also checked on a narrow screen, which is where I noticed the results list was covering up the chips, so it now sits below them.